### PR TITLE
Changed some warning messages to debug messages, after comparission o…

### DIFF
--- a/src/fs/fsck.rs
+++ b/src/fs/fsck.rs
@@ -34,6 +34,9 @@ pub struct FsckIssue {
     pub message: String,
     /// Whether this issue can be automatically repaired.
     pub repairable: bool,
+    /// Debug-level issue: only shown when debug output is enabled.
+    /// These are cosmetic/harmless findings (e.g. tiny wasted space).
+    pub debug: bool,
 }
 
 /// Aggregate statistics from a filesystem check.

--- a/src/fs/hfs.rs
+++ b/src/fs/hfs.rs
@@ -2579,6 +2579,83 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // manual test — requires real HFS image
+    fn test_fsck_pm6100_compare() {
+        let paths = [
+            (
+                "/Volumes/Software/VintageSystemBackups/HD40_imagedPowerMac6100.hda",
+                "ORIGINAL",
+            ),
+            (
+                "/Volumes/Software/VintageSystemBackups/DiskWarriorFixed/HD50_pm6100 hdd.hda",
+                "DISKWARRIOR FIXED",
+            ),
+        ];
+
+        for (path, label) in &paths {
+            let p = std::path::Path::new(path);
+            if !p.exists() {
+                eprintln!("Skipping {}: not found", path);
+                continue;
+            }
+            eprintln!("\n========== {} ==========", label);
+            eprintln!("File: {}", path);
+
+            let file = std::fs::File::open(p).unwrap();
+            let mut reader = std::io::BufReader::new(file);
+
+            // Find Apple_HFS partition in APM
+            let mut hfs_offset = 0u64;
+            for i in 1..64u64 {
+                use std::io::{Read, Seek};
+                reader.seek(SeekFrom::Start(i * 512)).unwrap();
+                let mut buf = [0u8; 512];
+                if reader.read_exact(&mut buf).is_err() {
+                    break;
+                }
+                if buf[0] != 0x50 || buf[1] != 0x4D {
+                    break;
+                }
+                let start = u32::from_be_bytes([buf[8], buf[9], buf[10], buf[11]]);
+                let count = u32::from_be_bytes([buf[12], buf[13], buf[14], buf[15]]);
+                let tstr: String = buf[48..80]
+                    .iter()
+                    .take_while(|&&b| b != 0)
+                    .map(|&b| b as char)
+                    .collect();
+                eprintln!(
+                    "  Part {}: {:32} start={:>8} blocks={:>8}",
+                    i, tstr, start, count
+                );
+                if tstr == "Apple_HFS" && hfs_offset == 0 {
+                    hfs_offset = start as u64 * 512;
+                }
+            }
+            eprintln!("  -> HFS partition at offset {}", hfs_offset);
+
+            let file2 = std::fs::File::open(p).unwrap();
+            let mut fs = HfsFilesystem::open(file2, hfs_offset).unwrap();
+            let result = fs.fsck().unwrap();
+
+            eprintln!("=== ERRORS ({}) ===", result.errors.len());
+            for e in &result.errors {
+                eprintln!("  [{}] {}", e.code, e.message);
+            }
+            eprintln!("=== WARNINGS ({}) ===", result.warnings.len());
+            for w in &result.warnings {
+                eprintln!("  [{}] {}", w.code, w.message);
+            }
+            eprintln!(
+                "=== STATS: {} files, {} dirs ===",
+                result.stats.files_checked, result.stats.directories_checked
+            );
+            for (k, v) in &result.stats.extra {
+                eprintln!("  {} = {}", k, v);
+            }
+        }
+    }
+
+    #[test]
     fn test_fsck_clean_fresh_image() {
         let img = make_editable_hfs_image();
         let cursor = Cursor::new(img);

--- a/src/fs/hfs_fsck.rs
+++ b/src/fs/hfs_fsck.rs
@@ -120,6 +120,16 @@ fn hfs_issue(code: HfsFsckCode, message: impl Into<String>) -> FsckIssue {
         code: format!("{:?}", code),
         message: message.into(),
         repairable: is_repairable(code),
+        debug: false,
+    }
+}
+
+fn hfs_debug_issue(code: HfsFsckCode, message: impl Into<String>) -> FsckIssue {
+    FsckIssue {
+        code: format!("{:?}", code),
+        message: message.into(),
+        repairable: false,
+        debug: true,
     }
 }
 
@@ -3652,33 +3662,52 @@ fn check_extents_and_bitmap(
         }
     }
 
-    // Compare computed bitmap vs actual volume bitmap
-    let mut mismatch_count = 0;
+    // Compare computed bitmap vs actual volume bitmap.
+    //
+    // "allocated in catalog but free in bitmap" is a real warning — a file's
+    // data block isn't protected, so it could be overwritten.
+    //
+    // "free in catalog but allocated in bitmap" is harmless — just a small
+    // amount of wasted space.  DiskWarrior also leaves these behind after
+    // directory rebuilds.  We report them as debug-level only.
+    let mut real_mismatch_count = 0usize;
+    let mut wasted_block_count = 0usize;
     for block in 0..total_blocks {
         let computed = bitmap_test_bit_be(&computed_bitmap, block);
         let actual = bitmap_test_bit_be(bitmap, block);
         if computed != actual {
-            mismatch_count += 1;
-            if mismatch_count <= MAX_BITMAP_MISMATCHES {
-                let direction = if computed {
-                    "allocated in catalog but free in bitmap"
-                } else {
-                    "free in catalog but allocated in bitmap"
-                };
-                warnings.push(hfs_issue(
-                    HfsFsckCode::BitmapMismatch,
-                    format!("block {}: {}", block, direction),
-                ));
+            if computed {
+                // File references this block but bitmap says free — real problem
+                real_mismatch_count += 1;
+                if real_mismatch_count <= MAX_BITMAP_MISMATCHES {
+                    warnings.push(hfs_issue(
+                        HfsFsckCode::BitmapMismatch,
+                        format!("block {}: allocated in catalog but free in bitmap", block),
+                    ));
+                }
+            } else {
+                // Bitmap says allocated but no file uses it — just wasted space
+                wasted_block_count += 1;
             }
         }
     }
-    if mismatch_count > MAX_BITMAP_MISMATCHES {
+    if real_mismatch_count > MAX_BITMAP_MISMATCHES {
         warnings.push(hfs_issue(
             HfsFsckCode::BitmapMismatch,
             format!(
                 "... and {} more bitmap mismatches (total {})",
-                mismatch_count - MAX_BITMAP_MISMATCHES,
-                mismatch_count
+                real_mismatch_count - MAX_BITMAP_MISMATCHES,
+                real_mismatch_count
+            ),
+        ));
+    }
+    if wasted_block_count > 0 {
+        warnings.push(hfs_debug_issue(
+            HfsFsckCode::BitmapMismatch,
+            format!(
+                "{} block(s) marked allocated in bitmap but not referenced by any file \
+                 (probably just small wasted space)",
+                wasted_block_count
             ),
         ));
     }

--- a/src/gui/browse_view.rs
+++ b/src/gui/browse_view.rs
@@ -124,6 +124,8 @@ pub struct BrowseView {
     fsck_result: Option<rusty_backup::fs::FsckResult>,
     /// Whether to show the fsck results popup.
     show_fsck_popup: bool,
+    /// Whether to show debug-level fsck messages.
+    show_fsck_debug: bool,
     /// Whether to show the repair confirmation dialog.
     show_repair_confirm: bool,
     /// Result of a repair operation.
@@ -185,6 +187,7 @@ impl Default for BrowseView {
             blessed_folder: None,
             fsck_result: None,
             show_fsck_popup: false,
+            show_fsck_debug: false,
             show_repair_confirm: false,
             repair_report: None,
             tree_text: None,
@@ -1756,21 +1759,40 @@ impl BrowseView {
                             });
                     }
 
-                    // Warnings
-                    if !result.warnings.is_empty() {
+                    // Warnings (filter out debug-level unless toggled)
+                    let visible_warnings: Vec<_> = result
+                        .warnings
+                        .iter()
+                        .filter(|w| !w.debug || self.show_fsck_debug)
+                        .collect();
+                    let has_debug = result.warnings.iter().any(|w| w.debug);
+                    if !visible_warnings.is_empty() {
                         ui.separator();
                         ui.label(egui::RichText::new("Warnings:").strong());
                         egui::ScrollArea::vertical()
                             .id_salt("fsck_warnings")
                             .max_height(200.0)
                             .show(ui, |ui| {
-                                for issue in &result.warnings {
-                                    ui.colored_label(
-                                        egui::Color32::from_rgb(255, 200, 100),
-                                        format!("[{}] {}", issue.code, issue.message),
-                                    );
+                                for issue in &visible_warnings {
+                                    if issue.debug {
+                                        ui.colored_label(
+                                            egui::Color32::from_rgb(150, 150, 150),
+                                            format!("[DEBUG] {}", issue.message),
+                                        );
+                                    } else {
+                                        ui.colored_label(
+                                            egui::Color32::from_rgb(255, 200, 100),
+                                            format!("[{}] {}", issue.code, issue.message),
+                                        );
+                                    }
                                 }
                             });
+                    }
+                    if has_debug {
+                        ui.checkbox(
+                            &mut self.show_fsck_debug,
+                            "Show debug messages",
+                        );
                     }
 
                     // Repair button — only for repairable errors on non-archive sources

--- a/src/gui/inspect_tab.rs
+++ b/src/gui/inspect_tab.rs
@@ -98,6 +98,8 @@ pub struct InspectTab {
     fsck_result: Option<rusty_backup::fs::FsckResult>,
     /// Whether to show the fsck results popup.
     show_fsck_popup: bool,
+    /// Whether to show debug-level fsck messages.
+    show_fsck_debug: bool,
     /// Whether to show the repair confirmation dialog.
     show_repair_confirm: bool,
     /// Result of a repair operation.
@@ -271,6 +273,7 @@ impl Default for InspectTab {
             resize_popup: None,
             fsck_result: None,
             show_fsck_popup: false,
+            show_fsck_debug: false,
             show_repair_confirm: false,
             repair_report: None,
             repair_context: None,
@@ -2725,10 +2728,12 @@ impl InspectTab {
                                     result.stats.files_checked, result.stats.directories_checked,
                                 ));
                             } else {
+                                let visible_warns =
+                                    result.warnings.iter().filter(|w| !w.debug).count();
                                 log.warn(format!(
                                     "Filesystem check: {} error(s), {} warning(s)",
                                     result.errors.len(),
-                                    result.warnings.len(),
+                                    visible_warns,
                                 ));
                             }
                             self.fsck_result = Some(result);
@@ -2806,21 +2811,37 @@ impl InspectTab {
                             });
                     }
 
-                    // Warnings
-                    if !result.warnings.is_empty() {
+                    // Warnings (filter out debug-level unless toggled)
+                    let visible_warnings: Vec<_> = result
+                        .warnings
+                        .iter()
+                        .filter(|w| !w.debug || self.show_fsck_debug)
+                        .collect();
+                    let has_debug = result.warnings.iter().any(|w| w.debug);
+                    if !visible_warnings.is_empty() {
                         ui.separator();
                         ui.label(egui::RichText::new("Warnings:").strong());
                         egui::ScrollArea::vertical()
                             .id_salt("fsck_warnings_inspect")
                             .max_height(200.0)
                             .show(ui, |ui| {
-                                for issue in &result.warnings {
-                                    ui.colored_label(
-                                        egui::Color32::from_rgb(255, 200, 100),
-                                        format!("[{}] {}", issue.code, issue.message),
-                                    );
+                                for issue in &visible_warnings {
+                                    if issue.debug {
+                                        ui.colored_label(
+                                            egui::Color32::from_rgb(150, 150, 150),
+                                            format!("[DEBUG] {}", issue.message),
+                                        );
+                                    } else {
+                                        ui.colored_label(
+                                            egui::Color32::from_rgb(255, 200, 100),
+                                            format!("[{}] {}", issue.code, issue.message),
+                                        );
+                                    }
                                 }
                             });
+                    }
+                    if has_debug {
+                        ui.checkbox(&mut self.show_fsck_debug, "Show debug messages");
                     }
 
                     // Repair button


### PR DESCRIPTION
…f fixes provided with diskwarrior

  src/fs/fsck.rs — Added debug: bool field to FsckIssue. Debug-level issues are cosmetic/harmless findings hidden by default.

  src/fs/hfs_fsck.rs — Split bitmap mismatch handling:
  - "allocated in catalog but free in bitmap" stays as a regular warning (real problem — data could be overwritten)
  - "free in catalog but allocated in bitmap" is now a single debug-level summary: "N block(s) marked allocated in bitmap but not referenced by any file (probably just small wasted space)"

  src/gui/inspect_tab.rs and src/gui/browse_view.rs — Both fsck popup displays:
  - Filter out debug warnings by default
  - Show debug messages in gray with [DEBUG] prefix when toggled
  - Add a "Show debug messages" checkbox that only appears when debug messages exist
  - Log panel warning count excludes debug messages