### PR TITLE
Export raw img from dsk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,3 +100,4 @@ All OS-specific code lives in `src/os/`:
 - Disk I/O must be sector-aligned (512 bytes or 4KB).
 - Disable UI controls during active operations to prevent conflicts.
 - Use `Result<T>` and `?` for error propagation throughout.
+- **No Unicode glyphs in UI text or log messages.** The default egui font does not include emoji or symbol glyphs (e.g. `✓ ✗ ⚠ ← → • ✖ ℹ`), so they render as blank boxes on the user's screen. Use plain ASCII alternatives instead — `OK`, `Skipped`, `Warning`, `Back`, `->`, `-`, `X`, `Info:` — for log lines, button labels, dialog text, and any other user-visible string. The only exception is content read directly from a filesystem (e.g. symlink target arrows in the optical browse view), which we render verbatim.

--- a/src/backup/mod.rs
+++ b/src/backup/mod.rs
@@ -469,7 +469,7 @@ pub fn run_backup(config: BackupConfig, progress: Arc<Mutex<BackupProgress>>) ->
                                 partition::format_size(result.compacted_size),
                                 partition::format_size(result.original_size),
                                 if result.compacted_size == result.original_size {
-                                    "layout-preserving (free blocks → zeros)"
+                                    "layout-preserving (free blocks -> zeros)"
                                 } else {
                                     "packed"
                                 },
@@ -734,7 +734,7 @@ pub fn run_backup(config: BackupConfig, progress: Arc<Mutex<BackupProgress>>) ->
                     &progress,
                     LogLevel::Info,
                     format!(
-                        "Compacting {}: {} at LBA {}, trimmed {} → {} (free blocks → zeros)",
+                        "Compacting {}: {} at LBA {}, trimmed {} -> {} (free blocks -> zeros)",
                         part_label,
                         part.type_name,
                         part.start_lba,
@@ -747,7 +747,7 @@ pub fn run_backup(config: BackupConfig, progress: Arc<Mutex<BackupProgress>>) ->
                     &progress,
                     LogLevel::Info,
                     format!(
-                        "Compacting {}: {} at LBA {}, {} → {} (defragmented)",
+                        "Compacting {}: {} at LBA {}, {} -> {} (defragmented)",
                         part_label,
                         part.type_name,
                         part.start_lba,

--- a/src/fs/hfs.rs
+++ b/src/fs/hfs.rs
@@ -1124,7 +1124,7 @@ impl<R: Read + Seek> HfsFilesystem<R> {
     /// Locate the catalog record-data offset for a file or directory CNID.
     ///
     /// Directories always have a thread record (HFS spec mandates it), so we
-    /// look them up via the thread → key path. File thread records are
+    /// look them up via the thread -> key path. File thread records are
     /// optional in classic HFS — Finder, CiderPress2, and Inside Macintosh:
     /// Files all describe them as optional, and our `create_file` no longer
     /// emits them. So if the thread lookup fails, fall back to a leaf scan
@@ -1995,7 +1995,7 @@ fn build_empty_hfs_extents_btree_with_node_size(
     }
     let mut buf = vec![0u8; size];
 
-    // Header descriptor. fLink → first map node when one exists.
+    // Header descriptor. fLink -> first map node when one exists.
     if map_nodes > 0 {
         BigEndian::write_u32(&mut buf[0..4], 1);
     }
@@ -3122,7 +3122,7 @@ impl<R: Read + Seek> CompactHfsReader<R> {
         // data_size: pre-alloc is always read from disk; only allocated alloc blocks are read.
         let data_size = pre_alloc_size + allocated as u64 * mdb.block_size as u64;
         eprintln!(
-            "[HFS compact] pre_alloc_size={}, data_size={}, compacted_size={} original_size={} (layout-preserving; free blocks → zeros)",
+            "[HFS compact] pre_alloc_size={}, data_size={}, compacted_size={} original_size={} (layout-preserving; free blocks -> zeros)",
             pre_alloc_size, data_size, compacted_size, original_size
         );
 
@@ -3183,7 +3183,7 @@ impl<R: Read + Seek> Read for CompactHfsReader<R> {
         }
 
         // Phase 1: allocation blocks 0..total_blocks.
-        // Allocated blocks → real data; free blocks → zeros.
+        // Allocated blocks -> real data; free blocks -> zeros.
         let total_blocks = self.mdb.total_blocks as u32;
         if self.current_block >= total_blocks {
             self.phase = 2;
@@ -4222,9 +4222,9 @@ mod tests {
         // both padded and unpadded key paths in index records
         for i in 0..40 {
             let name = if i % 2 == 0 {
-                format!("f{:03}.txt", i) // 8 chars → key_len=14 (even) → needs pad
+                format!("f{:03}.txt", i) // 8 chars -> key_len=14 (even) -> needs pad
             } else {
-                format!("fi{:03}.txt", i) // 9 chars → key_len=15 (odd) → no pad
+                format!("fi{:03}.txt", i) // 9 chars -> key_len=15 (odd) -> no pad
             };
             let data = format!("data{}", i);
             let mut reader = Cursor::new(data.as_bytes().to_vec());
@@ -4483,7 +4483,7 @@ mod tests {
             create_blank_hfs_sized(64 * 1024 * 1024, block_size, "Sized", 64 * 1024, 256 * 1024)
                 .expect("create_blank_hfs_sized");
         let mut fs = HfsFilesystem::open(Cursor::new(img), 0).expect("open");
-        // 64 KiB / 32 KiB = 2 blocks → bumped to 4 (default floor).
+        // 64 KiB / 32 KiB = 2 blocks -> bumped to 4 (default floor).
         assert_eq!(fs.mdb().extents_file_size, 4 * block_size);
         // 256 KiB / 32 KiB = 8 blocks.
         assert_eq!(fs.mdb().catalog_file_size, 8 * block_size);
@@ -4791,7 +4791,7 @@ mod tests {
         assert_eq!(fs2.mdb.modify_date, modify);
         assert_eq!(BigEndian::read_u32(&fs2.mdb.raw_sector[64..68]), backup);
 
-        // No pending dates → sync stamps modify_date to hfs_now (different from `modify`).
+        // No pending dates -> sync stamps modify_date to hfs_now (different from `modify`).
         fs2.sync_metadata().unwrap();
         assert_ne!(fs2.mdb.modify_date, modify);
     }

--- a/src/fs/hfsplus.rs
+++ b/src/fs/hfsplus.rs
@@ -1957,7 +1957,7 @@ impl<R: Read + Seek> CompactHfsPlusReader<R> {
         // data_size: only allocated blocks require disk reads.
         let data_size = allocated as u64 * vh.block_size as u64;
         eprintln!(
-            "[HFS+ compact] compacted_size={} data_size={} original_size={} (layout-preserving; free blocks → zeros)",
+            "[HFS+ compact] compacted_size={} data_size={} original_size={} (layout-preserving; free blocks -> zeros)",
             compacted_size, data_size, original_size
         );
 

--- a/src/gui/browse_view.rs
+++ b/src/gui/browse_view.rs
@@ -986,9 +986,9 @@ impl BrowseView {
                     let desc = rusty_backup::fs::prodos_types::type_description(tt);
                     let aux = entry.aux_type.unwrap_or(0);
                     if desc.is_empty() {
-                        format!("{tc} • ${:04X}", aux)
+                        format!("{tc} ${:04X}", aux)
                     } else {
-                        format!("{desc} • ${:04X}", aux)
+                        format!("{desc} ${:04X}", aux)
                     }
                 });
 
@@ -1733,7 +1733,7 @@ impl BrowseView {
             // Remove old archive, compress temp → new archive
             let archive_base = archive_path.with_extension("");
             log::info!(
-                "Compressing {} → {} (type={})",
+                "Compressing {} -> {} (type={})",
                 temp_path.display(),
                 archive_base.display(),
                 compression_type
@@ -3092,7 +3092,7 @@ impl BrowseView {
                 } else {
                     ui.label(format!("{count} items already exist at the destination:"));
                     for name in &conflict_list {
-                        ui.label(format!("  • {name}"));
+                        ui.label(format!("  - {name}"));
                     }
                 }
                 ui.add_space(4.0);

--- a/src/gui/bulk_convert_dialog.rs
+++ b/src/gui/bulk_convert_dialog.rs
@@ -1,0 +1,782 @@
+//! Bulk Convert dialog: convert every disk image in a folder to one chosen
+//! output format, dropping results into a separate output folder.
+//!
+//! Reuses [`rusty_backup::rbformats::export::export_whole_disk`] (the same
+//! single-file path the Inspect tab uses) — there is no per-partition sizing
+//! in bulk mode, every disk exports at original size.
+//!
+//! Flow:
+//! 1. **Setup** — pick source folder, output folder, output format.
+//! 2. **Review** — scan source folder (no filtering); user un-checks any files
+//!    they want to skip. Files that fail to open / detect during conversion
+//!    surface as warnings in the log panel afterward.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use rusty_backup::rbformats::export::{export_whole_disk, ExportFormat};
+
+fn fmt_bytes(n: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+    if n >= GB {
+        format!("{:.2} GB", n as f64 / GB as f64)
+    } else if n >= MB {
+        format!("{:.1} MB", n as f64 / MB as f64)
+    } else if n >= KB {
+        format!("{:.1} KB", n as f64 / KB as f64)
+    } else {
+        format!("{} B", n)
+    }
+}
+
+/// Live state for a running bulk conversion job.
+pub struct BulkConvertStatus {
+    pub finished: bool,
+    pub cancel_requested: bool,
+    /// 1-based index of the file currently being processed.
+    pub current_index: usize,
+    pub total_files: usize,
+    pub current_file: String,
+    /// Bytes written for the currently-processing file (for the progress bar).
+    pub current_bytes: u64,
+    pub current_total_bytes: u64,
+    pub succeeded: usize,
+    pub failed: usize,
+    /// Drained by the main thread into the GUI log panel each frame.
+    pub log_messages: Vec<(LogLevel, String)>,
+}
+
+#[derive(Clone, Copy)]
+pub enum LogLevel {
+    Info,
+    Warn,
+    Error,
+}
+
+/// One entry in the review-phase checklist.
+pub struct ScannedFile {
+    pub path: PathBuf,
+    pub size: u64,
+    pub selected: bool,
+}
+
+/// One pending output filename collision.
+struct Conflict {
+    source: PathBuf,
+    /// Existing destination file in the output folder.
+    dest: PathBuf,
+}
+
+/// Which view of the dialog is active.
+enum Phase {
+    Setup,
+    Review {
+        files: Vec<ScannedFile>,
+        /// User-editable output extension (no leading dot). Defaults to the
+        /// recommended extension for the chosen format.
+        extension: String,
+        /// When the user clicks Start and one or more output files already
+        /// exist in the destination, we stash the collisions here and render
+        /// a confirmation modal instead of immediately emitting Start.
+        pending_conflicts: Option<Vec<Conflict>>,
+    },
+}
+
+/// Modal dialog state.
+pub struct BulkConvertDialog {
+    pub source_folder: Option<PathBuf>,
+    pub output_folder: Option<PathBuf>,
+    pub format: ExportFormat,
+    phase: Phase,
+    /// Set when scan returns no usable entries; surfaced inline in the dialog.
+    scan_error: Option<String>,
+}
+
+impl Default for BulkConvertDialog {
+    fn default() -> Self {
+        Self {
+            source_folder: None,
+            output_folder: None,
+            format: ExportFormat::Vhd,
+            phase: Phase::Setup,
+            scan_error: None,
+        }
+    }
+}
+
+/// Outcome of `show()` — caller acts on this to start the worker or close.
+pub enum DialogAction {
+    None,
+    /// User confirmed Start in the Review phase. Carries the list of selected
+    /// files so the worker doesn't have to re-scan.
+    Start {
+        files: Vec<PathBuf>,
+        extension: String,
+    },
+    Cancel,
+}
+
+impl BulkConvertDialog {
+    /// Render the dialog. Returns the user's intent for this frame.
+    pub fn show(&mut self, ctx: &egui::Context) -> DialogAction {
+        match self.phase {
+            Phase::Setup => self.show_setup(ctx),
+            Phase::Review { .. } => self.show_review(ctx),
+        }
+    }
+
+    fn show_setup(&mut self, ctx: &egui::Context) -> DialogAction {
+        let mut action = DialogAction::None;
+        let mut go_to_review = false;
+
+        egui::Window::new("Bulk Convert")
+            .collapsible(false)
+            .resizable(true)
+            .default_width(560.0)
+            .show(ctx, |ui| {
+                ui.label(
+                    "Convert every disk image in a folder to a single output format. \
+                     All files use the same parameters; original size is preserved.",
+                );
+                ui.add_space(8.0);
+
+                ui.horizontal(|ui| {
+                    ui.label(egui::RichText::new("Source folder:").strong());
+                    let label = self
+                        .source_folder
+                        .as_ref()
+                        .map(|p| p.display().to_string())
+                        .unwrap_or_else(|| "(not selected)".to_string());
+                    ui.label(label);
+                });
+                if ui.button("Choose Source Folder…").clicked() {
+                    if let Some(p) = super::file_dialog().pick_folder() {
+                        self.source_folder = Some(p);
+                    }
+                }
+
+                ui.add_space(6.0);
+
+                ui.horizontal(|ui| {
+                    ui.label(egui::RichText::new("Output folder:").strong());
+                    let label = self
+                        .output_folder
+                        .as_ref()
+                        .map(|p| p.display().to_string())
+                        .unwrap_or_else(|| "(not selected)".to_string());
+                    ui.label(label);
+                });
+                if ui.button("Choose Output Folder…").clicked() {
+                    if let Some(p) = super::file_dialog().pick_folder() {
+                        self.output_folder = Some(p);
+                    }
+                }
+
+                ui.add_space(8.0);
+
+                ui.label(egui::RichText::new("Output format:").strong());
+                ui.horizontal(|ui| {
+                    ui.radio_value(&mut self.format, ExportFormat::Vhd, "VHD");
+                    ui.radio_value(&mut self.format, ExportFormat::Raw, "Raw (.img)");
+                    ui.radio_value(&mut self.format, ExportFormat::TwoMg, "2MG (.2mg)");
+                    ui.radio_value(&mut self.format, ExportFormat::Woz, "WOZ (.woz)")
+                        .on_hover_text("Floppy only: 140K / 400K / 800K sources");
+                    ui.radio_value(&mut self.format, ExportFormat::Dc42, "DiskCopy 4.2 (.dsk)")
+                        .on_hover_text("Floppy only: 400K / 720K / 800K / 1440K sources");
+                });
+
+                if let (Some(src), Some(out)) = (&self.source_folder, &self.output_folder) {
+                    if src == out {
+                        ui.add_space(6.0);
+                        ui.colored_label(
+                            egui::Color32::YELLOW,
+                            "Warning: source and output folders are the same — converted files may overwrite originals.",
+                        );
+                    }
+                }
+
+                if let Some(err) = &self.scan_error {
+                    ui.add_space(6.0);
+                    ui.colored_label(egui::Color32::from_rgb(255, 100, 100), err);
+                }
+
+                ui.add_space(10.0);
+                ui.horizontal(|ui| {
+                    let ready =
+                        self.source_folder.is_some() && self.output_folder.is_some();
+                    if ui
+                        .add_enabled(ready, egui::Button::new("Scan…"))
+                        .on_hover_text("Read the source folder and review the file list before converting.")
+                        .clicked()
+                    {
+                        go_to_review = true;
+                    }
+                    if ui.button("Cancel").clicked() {
+                        action = DialogAction::Cancel;
+                    }
+                });
+            });
+
+        if go_to_review {
+            match scan_source_folder(self.source_folder.as_ref().unwrap()) {
+                Ok(files) if files.is_empty() => {
+                    self.scan_error = Some("No files found in source folder.".to_string());
+                }
+                Ok(files) => {
+                    self.scan_error = None;
+                    self.phase = Phase::Review {
+                        files,
+                        extension: self.format.extension().to_string(),
+                        pending_conflicts: None,
+                    };
+                }
+                Err(e) => {
+                    self.scan_error = Some(format!("Scan failed: {e}"));
+                }
+            }
+        }
+
+        action
+    }
+
+    fn show_review(&mut self, ctx: &egui::Context) -> DialogAction {
+        let mut action = DialogAction::None;
+        let mut go_back = false;
+        let mut start = false;
+        let mut select_all = false;
+        let mut select_none = false;
+
+        let recommended_ext = self.format.extension();
+        let output_folder = self.output_folder.clone();
+        let Phase::Review {
+            files,
+            extension,
+            pending_conflicts,
+        } = &mut self.phase
+        else {
+            return action;
+        };
+
+        egui::Window::new("Bulk Convert — Review")
+            .collapsible(false)
+            .resizable(true)
+            .default_width(640.0)
+            .default_height(500.0)
+            .show(ctx, |ui| {
+                let total = files.len();
+                let selected_count = files.iter().filter(|f| f.selected).count();
+
+                ui.label(format!(
+                    "Found {} file(s) in source folder. {} selected for conversion.",
+                    total, selected_count,
+                ));
+                ui.label(
+                    "Files that fail to open or aren't recognized as disk images will be \
+                     reported as warnings in the log after conversion finishes.",
+                );
+
+                ui.add_space(6.0);
+
+                // Extension field — pre-filled with the recommended extension
+                // for the chosen format. The user can override (e.g. ".hda"
+                // instead of ".vhd") and reset back to the recommendation.
+                ui.horizontal(|ui| {
+                    ui.label(egui::RichText::new("Output extension:").strong());
+                    ui.label(".");
+                    ui.add(
+                        egui::TextEdit::singleline(extension)
+                            .desired_width(80.0)
+                            .hint_text(recommended_ext),
+                    );
+                    if ui
+                        .add_enabled(
+                            extension.as_str() != recommended_ext,
+                            egui::Button::new("Reset"),
+                        )
+                        .on_hover_text(format!("Reset to recommended: .{recommended_ext}"))
+                        .clicked()
+                    {
+                        *extension = recommended_ext.to_string();
+                    }
+                    ui.label(
+                        egui::RichText::new(format!("(recommended: .{recommended_ext})")).weak(),
+                    );
+                });
+
+                ui.add_space(6.0);
+                ui.horizontal(|ui| {
+                    if ui.button("Select All").clicked() {
+                        select_all = true;
+                    }
+                    if ui.button("Select None").clicked() {
+                        select_none = true;
+                    }
+                });
+
+                ui.add_space(6.0);
+                ui.separator();
+
+                egui::ScrollArea::vertical()
+                    .auto_shrink([false; 2])
+                    .max_height(340.0)
+                    .show(ui, |ui| {
+                        egui::Grid::new("bulk_convert_files")
+                            .striped(true)
+                            .num_columns(3)
+                            .min_col_width(40.0)
+                            .show(ui, |ui| {
+                                ui.label(egui::RichText::new("").strong());
+                                ui.label(egui::RichText::new("File").strong());
+                                ui.label(egui::RichText::new("Size").strong());
+                                ui.end_row();
+
+                                for f in files.iter_mut() {
+                                    ui.checkbox(&mut f.selected, "");
+                                    let name =
+                                        f.path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                                    ui.label(name);
+                                    ui.label(fmt_bytes(f.size));
+                                    ui.end_row();
+                                }
+                            });
+                    });
+
+                ui.separator();
+                ui.add_space(6.0);
+                ui.horizontal(|ui| {
+                    if ui.button("Back").clicked() {
+                        go_back = true;
+                    }
+                    let ext_ok =
+                        !extension.trim().is_empty() && !extension.contains(['/', '\\', '.', ' ']);
+                    let can_start = selected_count > 0 && ext_ok;
+                    let label = format!("Start Conversion ({selected_count})");
+                    if ui
+                        .add_enabled(can_start, egui::Button::new(label))
+                        .clicked()
+                    {
+                        start = true;
+                    }
+                    if ui.button("Cancel").clicked() {
+                        action = DialogAction::Cancel;
+                    }
+                });
+            });
+
+        if select_all {
+            for f in files.iter_mut() {
+                f.selected = true;
+            }
+        }
+        if select_none {
+            for f in files.iter_mut() {
+                f.selected = false;
+            }
+        }
+        // If the user clicked Start, detect output-folder collisions before
+        // emitting the action. If any are found, populate `pending_conflicts`
+        // so the modal renders next frame; otherwise emit Start immediately.
+        let mut emit_start: Option<(Vec<PathBuf>, String)> = None;
+        if start {
+            let ext = extension.trim().to_string();
+            let chosen_paths: Vec<PathBuf> = files
+                .iter()
+                .filter(|f| f.selected)
+                .map(|f| f.path.clone())
+                .collect();
+
+            let conflicts = if let Some(out) = &output_folder {
+                detect_conflicts(&chosen_paths, out, &ext)
+            } else {
+                Vec::new()
+            };
+
+            if conflicts.is_empty() {
+                emit_start = Some((chosen_paths, ext));
+            } else {
+                *pending_conflicts = Some(conflicts);
+            }
+        }
+
+        // Render the conflict modal on top of the Review window if collisions
+        // are pending. Returns the user's resolution, if any.
+        let resolution = if let Some(conflicts) = pending_conflicts.as_ref() {
+            show_conflict_modal(ctx, conflicts)
+        } else {
+            ConflictResolution::None
+        };
+
+        match resolution {
+            ConflictResolution::SkipConflicting => {
+                let conflict_set: std::collections::HashSet<PathBuf> = pending_conflicts
+                    .as_ref()
+                    .map(|cs| cs.iter().map(|c| c.source.clone()).collect())
+                    .unwrap_or_default();
+                let chosen: Vec<PathBuf> = files
+                    .iter()
+                    .filter(|f| f.selected && !conflict_set.contains(&f.path))
+                    .map(|f| f.path.clone())
+                    .collect();
+                let ext = extension.trim().to_string();
+                *pending_conflicts = None;
+                if !chosen.is_empty() {
+                    emit_start = Some((chosen, ext));
+                }
+            }
+            ConflictResolution::Overwrite => {
+                let chosen: Vec<PathBuf> = files
+                    .iter()
+                    .filter(|f| f.selected)
+                    .map(|f| f.path.clone())
+                    .collect();
+                let ext = extension.trim().to_string();
+                *pending_conflicts = None;
+                emit_start = Some((chosen, ext));
+            }
+            ConflictResolution::Back => {
+                *pending_conflicts = None;
+            }
+            ConflictResolution::None => {}
+        }
+
+        // Drop the &mut borrow on self.phase before mutating it.
+        if go_back {
+            self.phase = Phase::Setup;
+        }
+        if let Some((files, extension)) = emit_start {
+            action = DialogAction::Start { files, extension };
+        }
+
+        action
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ConflictResolution {
+    None,
+    SkipConflicting,
+    Overwrite,
+    Back,
+}
+
+fn detect_conflicts(
+    sources: &[PathBuf],
+    output: &std::path::Path,
+    extension: &str,
+) -> Vec<Conflict> {
+    let mut out = Vec::new();
+    for src in sources {
+        let stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or("disk");
+        let dest = output.join(format!("{stem}.{extension}"));
+        if dest.exists() {
+            out.push(Conflict {
+                source: src.clone(),
+                dest,
+            });
+        }
+    }
+    out
+}
+
+fn show_conflict_modal(ctx: &egui::Context, conflicts: &[Conflict]) -> ConflictResolution {
+    let mut resolution = ConflictResolution::None;
+
+    egui::Window::new("Output Files Already Exist")
+        .collapsible(false)
+        .resizable(true)
+        .default_width(560.0)
+        .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+        .show(ctx, |ui| {
+            ui.label(format!(
+                "{} file(s) in the output folder would be overwritten by this conversion:",
+                conflicts.len(),
+            ));
+            ui.add_space(6.0);
+
+            egui::ScrollArea::vertical()
+                .auto_shrink([false; 2])
+                .max_height(200.0)
+                .show(ui, |ui| {
+                    for c in conflicts {
+                        let name = c.dest.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                        ui.label(format!("- {name}"));
+                    }
+                });
+
+            ui.add_space(8.0);
+            ui.label(
+                "Skip: leave existing files alone, convert only the non-conflicting ones.\n\
+                 Overwrite: replace the existing output files.",
+            );
+            ui.add_space(8.0);
+
+            ui.horizontal(|ui| {
+                if ui.button("Skip Conflicting").clicked() {
+                    resolution = ConflictResolution::SkipConflicting;
+                }
+                if ui.button("Overwrite").clicked() {
+                    resolution = ConflictResolution::Overwrite;
+                }
+                if ui.button("Back").clicked() {
+                    resolution = ConflictResolution::Back;
+                }
+            });
+        });
+
+    resolution
+}
+
+/// Read the source folder and return one entry per regular file. No filtering
+/// — the user picks what to skip in the Review phase. Hidden dotfiles are
+/// still excluded since they're rarely user-visible disk images and clutter
+/// the list (e.g. `.DS_Store` on macOS).
+fn scan_source_folder(source: &std::path::Path) -> std::io::Result<Vec<ScannedFile>> {
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(source)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(s) => s,
+            None => continue,
+        };
+        if name.starts_with('.') {
+            continue;
+        }
+        let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
+        out.push(ScannedFile {
+            path,
+            size,
+            selected: true,
+        });
+    }
+    out.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(out)
+}
+
+/// Spawn a worker thread that converts the supplied files into `output`.
+/// Returns the shared status handle.
+pub fn start_bulk_convert(
+    files: Vec<PathBuf>,
+    output: PathBuf,
+    format: ExportFormat,
+    extension: String,
+) -> Arc<Mutex<BulkConvertStatus>> {
+    let status = Arc::new(Mutex::new(BulkConvertStatus {
+        finished: false,
+        cancel_requested: false,
+        current_index: 0,
+        total_files: files.len(),
+        current_file: String::new(),
+        current_bytes: 0,
+        current_total_bytes: 0,
+        succeeded: 0,
+        failed: 0,
+        log_messages: Vec::new(),
+    }));
+
+    let status_thread = Arc::clone(&status);
+    std::thread::spawn(move || {
+        let status_panic = Arc::clone(&status_thread);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            run_bulk_convert(files, output, format, extension, status_thread);
+        }));
+        if let Err(payload) = result {
+            let msg = if let Some(s) = payload.downcast_ref::<&'static str>() {
+                (*s).to_string()
+            } else if let Some(s) = payload.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "(unknown panic payload)".to_string()
+            };
+            if let Ok(mut s) = status_panic.lock() {
+                s.log_messages.push((
+                    LogLevel::Error,
+                    format!("Bulk convert worker panicked: {msg}"),
+                ));
+                s.finished = true;
+            }
+        }
+    });
+
+    status
+}
+
+fn run_bulk_convert(
+    files: Vec<PathBuf>,
+    output: PathBuf,
+    format: ExportFormat,
+    extension: String,
+    status: Arc<Mutex<BulkConvertStatus>>,
+) {
+    let push_log = |level: LogLevel, msg: String| {
+        if let Ok(mut s) = status.lock() {
+            s.log_messages.push((level, msg));
+        }
+    };
+
+    push_log(
+        LogLevel::Info,
+        format!(
+            "Bulk convert: {} file(s), output -> {}",
+            files.len(),
+            output.display(),
+        ),
+    );
+
+    if let Err(e) = std::fs::create_dir_all(&output) {
+        push_log(
+            LogLevel::Error,
+            format!("Failed to create output folder {}: {}", output.display(), e),
+        );
+        if let Ok(mut s) = status.lock() {
+            s.finished = true;
+        }
+        return;
+    }
+
+    // Track skipped (failed) files so we can list them all in the final summary.
+    let mut skipped: Vec<(PathBuf, String)> = Vec::new();
+
+    for (idx, file) in files.iter().enumerate() {
+        if status.lock().map(|s| s.cancel_requested).unwrap_or(false) {
+            push_log(LogLevel::Warn, "Cancelled by user.".to_string());
+            break;
+        }
+
+        let stem = file
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("disk")
+            .to_string();
+        let dest = output.join(format!("{stem}.{extension}"));
+
+        let source_size = std::fs::metadata(file).map(|m| m.len()).unwrap_or(0);
+        if let Ok(mut s) = status.lock() {
+            s.current_index = idx + 1;
+            s.current_file = file
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("")
+                .to_string();
+            s.current_bytes = 0;
+            s.current_total_bytes = source_size;
+        }
+
+        push_log(
+            LogLevel::Info,
+            format!(
+                "[{}/{}] Converting {} ({}) -> {}",
+                idx + 1,
+                files.len(),
+                file.display(),
+                fmt_bytes(source_size),
+                dest.display(),
+            ),
+        );
+
+        let status_progress = Arc::clone(&status);
+        let status_cancel = Arc::clone(&status);
+        let status_log = Arc::clone(&status);
+
+        let started = Instant::now();
+        let log_for_progress = Arc::clone(&status);
+        let mut last_logged_bytes: u64 = 0;
+        const LOG_EVERY_BYTES: u64 = 64 * 1024 * 1024;
+
+        let result = export_whole_disk(
+            format,
+            file,
+            None,
+            None,
+            &[],
+            &dest,
+            move |bytes| {
+                if let Ok(mut s) = status_progress.lock() {
+                    s.current_bytes = bytes;
+                }
+                if bytes >= last_logged_bytes + LOG_EVERY_BYTES {
+                    last_logged_bytes = bytes;
+                    let elapsed = started.elapsed().as_secs_f64().max(0.001);
+                    let mbs = (bytes as f64 / 1_048_576.0) / elapsed;
+                    if let Ok(mut s) = log_for_progress.lock() {
+                        s.log_messages.push((
+                            LogLevel::Info,
+                            format!("    … {} written ({:.1} MB/s)", fmt_bytes(bytes), mbs),
+                        ));
+                    }
+                }
+            },
+            move || {
+                status_cancel
+                    .lock()
+                    .map(|s| s.cancel_requested)
+                    .unwrap_or(false)
+            },
+            move |msg| {
+                if let Ok(mut s) = status_log.lock() {
+                    s.log_messages.push((LogLevel::Info, msg.to_string()));
+                }
+            },
+        );
+
+        match result {
+            Ok(()) => {
+                if let Ok(mut s) = status.lock() {
+                    s.succeeded += 1;
+                }
+                let elapsed = started.elapsed().as_secs_f64();
+                push_log(
+                    LogLevel::Info,
+                    format!("  OK: {} (in {:.1}s)", dest.display(), elapsed),
+                );
+            }
+            Err(e) => {
+                if let Ok(mut s) = status.lock() {
+                    s.failed += 1;
+                }
+                let _ = std::fs::remove_file(&dest);
+                let reason = format!("{e:#}");
+                push_log(
+                    LogLevel::Warn,
+                    format!("  Skipped {} - {}", file.display(), reason),
+                );
+                skipped.push((file.clone(), reason));
+            }
+        }
+    }
+
+    // Final summary, including a per-file list of every skipped/failed entry.
+    let (succeeded, failed) = if let Ok(s) = status.lock() {
+        (s.succeeded, s.failed)
+    } else {
+        (0, 0)
+    };
+    push_log(
+        LogLevel::Info,
+        format!(
+            "Bulk convert finished: {} succeeded, {} skipped/failed.",
+            succeeded, failed,
+        ),
+    );
+    if !skipped.is_empty() {
+        push_log(
+            LogLevel::Warn,
+            format!("{} file(s) were skipped:", skipped.len()),
+        );
+        for (path, reason) in &skipped {
+            push_log(
+                LogLevel::Warn,
+                format!("  - {}: {}", path.display(), reason),
+            );
+        }
+    }
+    if let Ok(mut s) = status.lock() {
+        s.finished = true;
+    }
+}

--- a/src/gui/elevation_dialog.rs
+++ b/src/gui/elevation_dialog.rs
@@ -26,9 +26,9 @@ impl ElevationDialog {
                 ui.vertical_centered(|ui| {
                     ui.add_space(10.0);
                     ui.label(
-                        egui::RichText::new("⚠")
+                        egui::RichText::new("Warning")
                             .color(egui::Color32::YELLOW)
-                            .size(48.0),
+                            .size(24.0),
                     );
                     ui.add_space(10.0);
                 });

--- a/src/gui/expand_hfs_dialog.rs
+++ b/src/gui/expand_hfs_dialog.rs
@@ -319,7 +319,7 @@ impl ExpandHfsDialog {
         let target_bs = self.target_block_size;
 
         log.info(format!(
-            "Expanding HFS volume '{}' to {} MiB at {} KiB blocks → {}",
+            "Expanding HFS volume '{}' to {} MiB at {} KiB blocks -> {}",
             source.volume_name,
             self.target_size_mib,
             target_bs / 1024,

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1,5 +1,6 @@
 mod backup_tab;
 mod browse_view;
+mod bulk_convert_dialog;
 mod elevation_dialog;
 mod expand_hfs_dialog;
 mod inspect_tab;
@@ -10,6 +11,10 @@ mod restore_tab;
 mod settings_dialog;
 
 use backup_tab::BackupTab;
+use bulk_convert_dialog::{
+    BulkConvertDialog, BulkConvertStatus, DialogAction as BulkConvertAction,
+    LogLevel as BulkConvertLogLevel,
+};
 use inspect_tab::InspectTab;
 use optical_tab::OpticalTab;
 use progress::{LogPanel, ProgressState};
@@ -30,6 +35,21 @@ use std::thread;
 /// Create an `rfd::FileDialog` pre-configured to start in the real user's home
 /// directory. This ensures file dialogs open in the right place even when the
 /// app is running elevated via pkexec.
+fn bytes_human(n: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+    if n >= GB {
+        format!("{:.2} GB", n as f64 / GB as f64)
+    } else if n >= MB {
+        format!("{:.1} MB", n as f64 / MB as f64)
+    } else if n >= KB {
+        format!("{:.1} KB", n as f64 / KB as f64)
+    } else {
+        format!("{} B", n)
+    }
+}
+
 fn file_dialog() -> rfd::FileDialog {
     let dialog = rfd::FileDialog::new();
     #[cfg(target_os = "linux")]
@@ -66,6 +86,10 @@ pub struct RustyBackupApp {
     elevation_dialog: ElevationDialog,
     /// Shared backup folder path between restore and inspect tabs
     loaded_backup_folder: Option<PathBuf>,
+    /// Bulk Convert dialog state (None = closed).
+    bulk_convert_dialog: Option<BulkConvertDialog>,
+    /// Background bulk-convert worker progress (None = idle).
+    bulk_convert_status: Option<Arc<Mutex<BulkConvertStatus>>>,
 }
 
 impl Default for RustyBackupApp {
@@ -154,6 +178,33 @@ impl Default for RustyBackupApp {
             #[cfg(target_os = "linux")]
             elevation_dialog,
             loaded_backup_folder: None,
+            bulk_convert_dialog: None,
+            bulk_convert_status: None,
+        }
+    }
+}
+
+impl RustyBackupApp {
+    /// Drain bulk-convert worker log messages into the GUI log panel and
+    /// clear the status handle when the worker finishes.
+    fn poll_bulk_convert(&mut self) {
+        let status_arc = match &self.bulk_convert_status {
+            Some(s) => Arc::clone(s),
+            None => return,
+        };
+        let Ok(mut status) = status_arc.lock() else {
+            return;
+        };
+        for (level, msg) in status.log_messages.drain(..) {
+            match level {
+                BulkConvertLogLevel::Info => self.log_panel.info(msg),
+                BulkConvertLogLevel::Warn => self.log_panel.warn(msg),
+                BulkConvertLogLevel::Error => self.log_panel.error(msg),
+            }
+        }
+        if status.finished {
+            drop(status);
+            self.bulk_convert_status = None;
         }
     }
 }
@@ -161,9 +212,16 @@ impl Default for RustyBackupApp {
 impl eframe::App for RustyBackupApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         // Request repaint while backup/restore is running so progress updates are shown
-        if self.progress.active || self.restore_tab.is_running() || self.optical_tab.is_running() {
+        if self.progress.active
+            || self.restore_tab.is_running()
+            || self.optical_tab.is_running()
+            || self.bulk_convert_status.is_some()
+        {
             ctx.request_repaint();
         }
+
+        // Drain bulk-convert worker logs into the panel and clear when done.
+        self.poll_bulk_convert();
 
         // Top panel: tab bar
         egui::TopBottomPanel::top("tab_bar").show(ctx, |ui| {
@@ -201,7 +259,7 @@ impl eframe::App for RustyBackupApp {
                             if let Ok(status) = access.check_status() {
                                 if status == rusty_backup::privileged::AccessStatus::NeedsElevation {
                                     if ui
-                                        .button(egui::RichText::new("⚠ Request Elevation").color(egui::Color32::YELLOW))
+                                        .button(egui::RichText::new("Request Elevation").color(egui::Color32::YELLOW))
                                         .on_hover_text("Restart with administrator privileges to access disk devices")
                                         .clicked()
                                     {
@@ -219,9 +277,90 @@ impl eframe::App for RustyBackupApp {
                             .info(format!("Refreshed: {} device(s) found", self.devices.len()));
                         ctx.request_repaint();
                     }
+                    ui.separator();
+
+                    // Bulk Convert — convert every disk image in a folder.
+                    let bulk_running = self.bulk_convert_status.is_some();
+                    if ui
+                        .add_enabled(!bulk_running, egui::Button::new("Bulk Convert…"))
+                        .on_hover_text(
+                            "Convert every disk image in a folder to one chosen format, \
+                             using the same parameters for every file.",
+                        )
+                        .clicked()
+                    {
+                        self.bulk_convert_dialog = Some(BulkConvertDialog::default());
+                    }
+                    if bulk_running {
+                        if ui.button("Cancel Bulk").clicked() {
+                            if let Some(ref s) = self.bulk_convert_status {
+                                if let Ok(mut g) = s.lock() {
+                                    g.cancel_requested = true;
+                                }
+                            }
+                            self.log_panel.warn("Bulk convert cancellation requested...");
+                        }
+                    }
                 });
             });
         });
+
+        // Bulk Convert dialog (modal-ish window, always reachable).
+        if let Some(ref mut dlg) = self.bulk_convert_dialog {
+            match dlg.show(ctx) {
+                BulkConvertAction::Start { files, extension } => {
+                    if let Some(out) = dlg.output_folder.clone() {
+                        let format = dlg.format;
+                        let count = files.len();
+                        self.bulk_convert_dialog = None;
+                        self.log_panel.info(format!(
+                            "Starting bulk convert: {count} file(s) -> {} ({}, .{extension})",
+                            out.display(),
+                            format.description(),
+                        ));
+                        self.bulk_convert_status = Some(bulk_convert_dialog::start_bulk_convert(
+                            files, out, format, extension,
+                        ));
+                    }
+                }
+                BulkConvertAction::Cancel => {
+                    self.bulk_convert_dialog = None;
+                }
+                BulkConvertAction::None => {}
+            }
+        }
+
+        // Bulk Convert progress strip — visible from any tab while running.
+        if let Some(ref status_arc) = self.bulk_convert_status {
+            if let Ok(s) = status_arc.lock() {
+                if !s.finished {
+                    let frac = if s.current_total_bytes > 0 {
+                        (s.current_bytes as f32 / s.current_total_bytes as f32).clamp(0.0, 1.0)
+                    } else {
+                        0.0
+                    };
+                    let text = if s.current_total_bytes > 0 {
+                        format!(
+                            "Bulk Convert: [{}/{}] {} — {} / {} ({:.0}%)",
+                            s.current_index,
+                            s.total_files,
+                            s.current_file,
+                            bytes_human(s.current_bytes),
+                            bytes_human(s.current_total_bytes),
+                            frac * 100.0,
+                        )
+                    } else {
+                        format!(
+                            "Bulk Convert: [{}/{}] {} — preparing…",
+                            s.current_index, s.total_files, s.current_file,
+                        )
+                    };
+                    egui::TopBottomPanel::top("bulk_convert_progress").show(ctx, |ui| {
+                        ui.add(egui::ProgressBar::new(frac).text(text));
+                    });
+                }
+            }
+        }
 
         // Update notification banner (if update available and not dismissed)
         if !self.update_dismissed {
@@ -230,12 +369,12 @@ impl eframe::App for RustyBackupApp {
                     egui::TopBottomPanel::top("update_banner").show(ctx, |ui| {
                         ui.horizontal(|ui| {
                             ui.label(
-                                egui::RichText::new("⚠")
+                                egui::RichText::new("Update")
                                     .color(egui::Color32::YELLOW)
-                                    .size(20.0),
+                                    .strong(),
                             );
                             ui.label(format!(
-                                "Update available: v{} → v{}",
+                                "available: v{} -> v{}",
                                 info.current_version, info.latest_version
                             ));
                             if ui.button("View Release").clicked() {
@@ -244,7 +383,7 @@ impl eframe::App for RustyBackupApp {
                             ui.with_layout(
                                 egui::Layout::right_to_left(egui::Align::Center),
                                 |ui| {
-                                    if ui.button("✖").clicked() {
+                                    if ui.button("Dismiss update notification").clicked() {
                                         self.update_dismissed = true;
                                     }
                                 },

--- a/src/gui/resize_popup.rs
+++ b/src/gui/resize_popup.rs
@@ -239,7 +239,7 @@ impl ResizePopup {
                             ui.label(egui::RichText::new("#").strong());
                             ui.label(egui::RichText::new("Old Start").strong());
                             ui.label(egui::RichText::new("Old Size").strong());
-                            ui.label(egui::RichText::new("→ New Start").strong());
+                            ui.label(egui::RichText::new("New Start").strong());
                             ui.label(egui::RichText::new("New Size").strong());
                             ui.label(egui::RichText::new("Action").strong());
                             ui.end_row();

--- a/src/gui/settings_dialog.rs
+++ b/src/gui/settings_dialog.rs
@@ -53,8 +53,8 @@ impl SettingsDialog {
 
                         ui.horizontal(|ui| {
                             ui.label(
-                                egui::RichText::new("ℹ")
-                                    .size(16.0)
+                                egui::RichText::new("Info:")
+                                    .size(14.0)
                                     .color(egui::Color32::from_rgb(0, 122, 255))
                             );
                             ui.vertical(|ui| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ fn main() -> eframe::Result {
             // Already root (elevated relaunch landed here) — set permissive umask
             // so backup files are created with 666/777 permissions accessible to the real user.
             rusty_backup::os::linux::set_permissive_umask_if_elevated();
-            eprintln!("Running with administrator privileges ✓");
+            eprintln!("Running with administrator privileges");
         }
     }
 

--- a/src/rbformats/chd.rs
+++ b/src/rbformats/chd.rs
@@ -210,7 +210,7 @@ pub(crate) fn compress_chd(
 
     let chd_path = output_path(output_base, "chd", false, 0);
     log_cb(&format!(
-        "Running chdman createraw → {}",
+        "Running chdman createraw -> {}",
         chd_path.display()
     ));
     let chdman_cmd = get_chdman_command();

--- a/src/rbformats/export.rs
+++ b/src/rbformats/export.rs
@@ -144,7 +144,7 @@ fn write_dc42_from_sectors(
     std::fs::write(dest_path, &bytes)
         .with_context(|| format!("failed to write {}", dest_path.display()))?;
     log_cb(&format!(
-        "DiskCopy 4.2 export complete: {} ({} input bytes → {} DC42 bytes)",
+        "DiskCopy 4.2 export complete: {} ({} input bytes -> {} DC42 bytes)",
         dest_path.display(),
         sectors.len(),
         bytes.len(),
@@ -166,7 +166,7 @@ fn write_woz_from_sectors(
     std::fs::write(dest_path, &bytes)
         .with_context(|| format!("failed to write {}", dest_path.display()))?;
     log_cb(&format!(
-        "WOZ export complete: {} ({} input bytes → {} WOZ bytes)",
+        "WOZ export complete: {} ({} input bytes -> {} WOZ bytes)",
         dest_path.display(),
         sectors.len(),
         bytes.len(),

--- a/src/rbformats/mod.rs
+++ b/src/rbformats/mod.rs
@@ -807,11 +807,13 @@ fn write_zeros_with_progress(
 pub fn detect_raw_apm(reader: &mut (impl Read + Seek)) -> Option<Apm> {
     reader.seek(SeekFrom::Start(0)).ok()?;
     let mut ddr = [0u8; 4];
-    reader.read_exact(&mut ddr).ok()?;
-    if &ddr[0..2] != b"ER" {
+    let read_ok = reader.read_exact(&mut ddr).is_ok();
+    // Always restore the cursor to 0 so callers that fall through to a
+    // sequential read of the unwrapped stream don't lose the first bytes.
+    reader.seek(SeekFrom::Start(0)).ok()?;
+    if !read_ok || &ddr[0..2] != b"ER" {
         return None;
     }
-    reader.seek(SeekFrom::Start(0)).ok()?;
     Apm::parse(reader).ok()
 }
 


### PR DESCRIPTION
Add Bulk Convert, clean up Unicode glyphs in UI, fix bugs in .dsk conversion process
  Bulk Convert
  ------------
  New "Bulk Convert…" button in the top toolbar (next to Refresh
  Devices, available regardless of the loaded source). Two-phase flow:

    1. Setup — pick source folder, output folder, output format
       (VHD / Raw / 2MG / WOZ / DiskCopy 4.2).
    2. Review — scan the source folder and show every regular file in a
       scrollable checklist with size; user un-checks anything they
       don't want converted. The output extension is pre-filled with
       the recommended one for the chosen format and is editable
       (e.g. ".hda" instead of ".vhd"); a Reset button restores the
       default.

  Before starting, the dialog scans the output folder for
  <stem>.<extension> collisions and prompts Skip Conflicting /
  Overwrite / Back if any are found.

  Conversions run on a background thread, share the existing
  export_whole_disk path used by the single-file Export button (so all
  five formats work for free), and stream per-file progress
  (filename, bytes / total, percentage) into a top-of-window progress
  strip plus a periodic throughput line in the log panel. Failures are
  reported as warnings inline and re-listed in a final summary so the
  user can see exactly which files were skipped and why. Worker panics
  are caught and surfaced rather than silently freezing the UI.

  UI text cleanup
  ---------------
  Removed Unicode-only glyphs that were rendering as blank boxes in the
  default egui font: ✓ ✗ ⚠ ← • ✖ ℹ → across log messages and dialogs
  (bulk-convert flow, update banner, elevation request, settings info
  hint, expand-HFS, resize popup, ProDOS type display, browse-view
  conflict list, backup/rbformats logs). Filesystem-content displays
  (symlink targets in the optical browse view) and code comments are
  left as-is. Update banner's dismiss button now reads "Dismiss update
  notification" instead of an unrendered X.