### PR TITLE
Rusty cli hfs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,18 @@ jobs:
           name: Rusty-Backup-windows-${{ matrix.arch }}-${{ needs.generate-version.outputs.version }}
           path: Rusty-Backup-windows-${{ matrix.arch }}-${{ needs.generate-version.outputs.version }}.zip
 
+      - name: Stage CLI binary
+        shell: bash
+        run: |
+          cp "target/${{ matrix.target }}/release/rusty-backup-cli.exe" \
+             "Rusty-Backup-CLI-windows-${{ matrix.arch }}-${{ needs.generate-version.outputs.version }}.exe"
+
+      - name: Upload CLI artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: Rusty-Backup-CLI-windows-${{ matrix.arch }}-${{ needs.generate-version.outputs.version }}
+          path: Rusty-Backup-CLI-windows-${{ matrix.arch }}-${{ needs.generate-version.outputs.version }}.exe
+
   build-macos:
     name: Build macOS
     needs: generate-version
@@ -246,6 +258,46 @@ jobs:
           echo "Stapling notarization ticket..."
           xcrun stapler staple "$DMG_FILE"
 
+      - name: Sign CLI binary
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_TEAM_ID: ${{ secrets.MACOS_TEAM_ID }}
+        run: |
+          CLI_BIN="target/${{ matrix.target }}/release/rusty-backup-cli"
+          if [ -n "$MACOS_CERTIFICATE" ] && [ -n "$MACOS_TEAM_ID" ]; then
+            IDENTITY=$(security find-identity -v -p codesigning "$RUNNER_TEMP/app-signing.keychain-db" | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)".*/\1/')
+            echo "Signing CLI with identity: $IDENTITY"
+            codesign --force --options runtime --timestamp --sign "$IDENTITY" "$CLI_BIN"
+          else
+            echo "No signing certificate found, using ad-hoc signature..."
+            codesign --force --sign - "$CLI_BIN"
+          fi
+
+      - name: Package CLI for notarization
+        run: |
+          ZIP_NAME="Rusty-Backup-CLI-macos-${{ matrix.arch }}-${{ needs.generate-version.outputs.version }}.zip"
+          # ditto produces the zip layout notarytool / Gatekeeper expect for
+          # loose binaries; plain `zip` works too but ditto is the canonical
+          # tool on macOS.
+          ditto -c -k --keepParent "target/${{ matrix.target }}/release/rusty-backup-cli" "$ZIP_NAME"
+
+      - name: Notarize CLI
+        if: ${{ env.HAS_SIGNING_CERT == 'true' }}
+        env:
+          MACOS_NOTARIZE_APPLE_ID: ${{ secrets.MACOS_NOTARIZE_APPLE_ID }}
+          MACOS_NOTARIZE_PASSWORD: ${{ secrets.MACOS_NOTARIZE_PASSWORD }}
+          MACOS_TEAM_ID: ${{ secrets.MACOS_TEAM_ID }}
+        run: |
+          ZIP_NAME="Rusty-Backup-CLI-macos-${{ matrix.arch }}-${{ needs.generate-version.outputs.version }}.zip"
+          echo "Submitting CLI zip for notarization..."
+          xcrun notarytool submit "$ZIP_NAME" \
+            --apple-id "$MACOS_NOTARIZE_APPLE_ID" \
+            --password "$MACOS_NOTARIZE_PASSWORD" \
+            --team-id "$MACOS_TEAM_ID" \
+            --wait
+          # Stapler can't attach a ticket to a bare binary inside a zip;
+          # Gatekeeper performs an online check on first launch instead.
+
       - name: Cleanup keychain
         if: always()
         run: |
@@ -253,12 +305,18 @@ jobs:
           if [ -f "$KEYCHAIN_PATH" ]; then
             security delete-keychain "$KEYCHAIN_PATH"
           fi
-      
+
       - name: Upload artifact
         uses: actions/upload-artifact@v6
         with:
           name: Rusty-Backup-macos-${{ matrix.arch }}-${{ needs.generate-version.outputs.version }}
           path: Rusty-Backup-macos-${{ matrix.arch }}-${{ needs.generate-version.outputs.version }}.dmg
+
+      - name: Upload CLI artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: Rusty-Backup-CLI-macos-${{ matrix.arch }}-${{ needs.generate-version.outputs.version }}
+          path: Rusty-Backup-CLI-macos-${{ matrix.arch }}-${{ needs.generate-version.outputs.version }}.zip
 
   build-linux-appimage:
     name: Build Linux AppImage (Anylinux)
@@ -462,7 +520,7 @@ jobs:
             runs-on: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
             arch: arm64
-            runs-on: [self-hosted, linux, ARM64]
+            runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v5
 
@@ -563,6 +621,17 @@ jobs:
           name: Rusty-Backup-linux-${{ matrix.arch }}-${{ needs.generate-version.outputs.version }}-arch
           path: Rusty-Backup-linux-${{ matrix.arch }}-${{ needs.generate-version.outputs.version }}.pkg.tar.zst
 
+      - name: Package CLI
+        run: |
+          TGZ="Rusty-Backup-CLI-linux-${{ matrix.arch }}-${{ needs.generate-version.outputs.version }}.tar.gz"
+          tar -C "target/${{ matrix.target }}/release" -czf "$TGZ" rusty-backup-cli
+
+      - name: Upload CLI artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: Rusty-Backup-CLI-linux-${{ matrix.arch }}-${{ needs.generate-version.outputs.version }}
+          path: Rusty-Backup-CLI-linux-${{ matrix.arch }}-${{ needs.generate-version.outputs.version }}.tar.gz
+
   release:
     name: Create Release
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
@@ -580,7 +649,7 @@ jobs:
       - name: Flatten artifacts
         run: |
           mkdir -p release-files
-          find artifacts -type f \( -name "*.zip" -o -name "*.dmg" -o -name "*.AppImage" -o -name "*.AppImage.zsync" -o -name "*.deb" -o -name "*.rpm" -o -name "*.pkg.tar.zst" \) -exec cp {} release-files/ \;
+          find artifacts -type f \( -name "*.zip" -o -name "*.dmg" -o -name "*.AppImage" -o -name "*.AppImage.zsync" -o -name "*.deb" -o -name "*.rpm" -o -name "*.pkg.tar.zst" -o -name "*.exe" -o -name "*.tar.gz" \) -exec cp {} release-files/ \;
           ls -lh release-files/
       
       - name: Create Release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "claxon"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4238,6 +4278,7 @@ dependencies = [
  "cargo-husky",
  "cd-da-reader",
  "chrono",
+ "clap",
  "crc32c",
  "crc32fast",
  "dirs",
@@ -4633,6 +4674,12 @@ name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,11 @@ resolver = "2"
 name = "rusty-backup"
 path = "src/main.rs"
 
+# Headless CLI binary — scripted image construction, no eframe dependency.
+[[bin]]
+name = "rusty-backup-cli"
+path = "src/bin/cli.rs"
+
 [[example]]
 name = "probe_hfs_btree"
 path = "example/probe_hfs_btree.rs"
@@ -35,6 +40,7 @@ egui = "0.34"
 rfd = { version = "0.17", default-features = false, features = ["gtk3"] }
 anyhow = "1"
 thiserror = "2"
+clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 byteorder = "1"

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,0 +1,21 @@
+//! Headless CLI entry point. The GUI binary (`rusty-backup`) does not call
+//! into this; both bins share the parsing + handler code in
+//! `rusty_backup::cli`.
+
+use clap::Parser;
+
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
+        .format_timestamp_millis()
+        .init();
+
+    let cli = rusty_backup::cli::Cli::parse();
+    let code = match rusty_backup::cli::run(cli) {
+        Ok(()) => 0,
+        Err(e) => {
+            eprintln!("error: {e:#}");
+            1
+        }
+    };
+    std::process::exit(code);
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,550 @@
+//! Command-line surface for rusty-backup.
+//!
+//! Everything currently lives under an `api` top-level namespace that is
+//! explicitly unstable: it exists so scripted consumers (build pipelines,
+//! automated tests) have *something* to call today, without committing to
+//! the eventual GUI-mirroring grammar (`inspect`, `backup`, `restore`,
+//! `optical`, `browse`, `shell`, ...). Expect verbs under `api` to be
+//! renamed or moved when that final structure lands.
+//!
+//! Mac paths on the CLI use `/` as the separator. `/` is illegal in HFS
+//! filenames so there's no ambiguity. The HFS native separator `:` is
+//! not accepted to keep the surface small and shell-friendly.
+
+use anyhow::{anyhow, bail, Context, Result};
+use clap::{Parser, Subcommand};
+use std::fs::OpenOptions;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::PathBuf;
+
+use crate::fs::filesystem::{CreateFileOptions, EditableFilesystem, Filesystem};
+use crate::fs::hfs::{create_blank_hfs_sized, validate_hfs_integrity, HfsFilesystem};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "rusty-backup-cli",
+    about = "Headless image-construction CLI for rusty-backup",
+    disable_help_subcommand = true
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Unstable scratch namespace for low-level operations. Grammar inside
+    /// `api` is expected to churn — do not depend on it from durable scripts.
+    Api {
+        #[command(subcommand)]
+        group: ApiGroup,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ApiGroup {
+    /// Classic-HFS image operations (create, browse, edit single-partition .dsk images).
+    Hfs {
+        #[command(subcommand)]
+        verb: HfsCommand,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum HfsCommand {
+    /// Create a fresh blank HFS volume at the given path.
+    New {
+        /// Image file to create. Overwritten if it already exists.
+        image: PathBuf,
+        /// Volume size, accepting plain bytes or `K`/`KiB`/`M`/`MiB` suffixes
+        /// (e.g. `800K`, `5M`). Defaults to 800K (an 800 KiB floppy).
+        #[arg(long, default_value = "800K")]
+        size: String,
+        /// HFS volume name (1..=27 Mac Roman bytes). Defaults to `MacIIBench`.
+        #[arg(long, default_value = "MacIIBench")]
+        name: String,
+        /// HFS allocation block size in bytes. Must be a non-zero multiple of
+        /// 512. When unset, the smallest size that keeps `total_blocks <=
+        /// 65535` is chosen automatically (e.g. 512 for floppies, larger for
+        /// multi-MiB SCSI images).
+        #[arg(long = "block-size")]
+        block_size: Option<u32>,
+    },
+    /// Print volume name, sizes, and counts for an HFS image.
+    Info { image: PathBuf },
+    /// List a directory inside the HFS volume.
+    Ls {
+        image: PathBuf,
+        /// Mac path (use `/` separators). Defaults to root.
+        #[arg(default_value = "/")]
+        path: String,
+    },
+    /// Copy a host file into the HFS volume.
+    Put {
+        image: PathBuf,
+        /// Source file on the host.
+        host_file: PathBuf,
+        /// Destination Mac path inside the volume. The parent directory must
+        /// already exist.
+        mac_path: String,
+        /// HFS 4-character type code. Defaults to `BINA`.
+        #[arg(long = "type", default_value = "BINA")]
+        type_code: String,
+        /// HFS 4-character creator code. Defaults to `????`.
+        #[arg(long, default_value = "????")]
+        creator: String,
+        /// Overwrite an existing entry at the destination path.
+        #[arg(long)]
+        force: bool,
+    },
+    /// Pre-allocate a zero-filled file at the given Mac path. Useful for
+    /// reserving a results file the boot ROM will fill in.
+    PutZero {
+        image: PathBuf,
+        mac_path: String,
+        /// Number of zero bytes to allocate.
+        size: u64,
+        #[arg(long = "type", default_value = "BINA")]
+        type_code: String,
+        #[arg(long, default_value = "????")]
+        creator: String,
+        #[arg(long)]
+        force: bool,
+    },
+    /// Extract an HFS file to the host.
+    Get {
+        image: PathBuf,
+        mac_path: String,
+        host_file: PathBuf,
+    },
+    /// Delete a file from the HFS volume.
+    Rm { image: PathBuf, mac_path: String },
+    /// Overwrite the 1024-byte boot block region at offset 0. The source
+    /// must be at most 1024 bytes and is written verbatim — no padding,
+    /// no HFS B-tree touch.
+    PutBoot { image: PathBuf, bb_file: PathBuf },
+    /// Run the lightweight HFS integrity check on the image.
+    Validate { image: PathBuf },
+}
+
+/// Run the parsed CLI and exit. Returns only when nothing matched (which
+/// can't happen with the current grammar) so callers can fall through to
+/// the GUI launcher.
+pub fn run(cli: Cli) -> Result<()> {
+    match cli.command {
+        Command::Api { group } => match group {
+            ApiGroup::Hfs { verb } => run_hfs(verb),
+        },
+    }
+}
+
+fn run_hfs(verb: HfsCommand) -> Result<()> {
+    match verb {
+        HfsCommand::New {
+            image,
+            size,
+            name,
+            block_size,
+        } => cmd_new(image, &size, &name, block_size),
+        HfsCommand::Info { image } => cmd_info(image),
+        HfsCommand::Ls { image, path } => cmd_ls(image, &path),
+        HfsCommand::Put {
+            image,
+            host_file,
+            mac_path,
+            type_code,
+            creator,
+            force,
+        } => cmd_put(
+            image,
+            Some(host_file),
+            &mac_path,
+            &type_code,
+            &creator,
+            None,
+            force,
+        ),
+        HfsCommand::PutZero {
+            image,
+            mac_path,
+            size,
+            type_code,
+            creator,
+            force,
+        } => cmd_put(
+            image,
+            None,
+            &mac_path,
+            &type_code,
+            &creator,
+            Some(size),
+            force,
+        ),
+        HfsCommand::Get {
+            image,
+            mac_path,
+            host_file,
+        } => cmd_get(image, &mac_path, host_file),
+        HfsCommand::Rm { image, mac_path } => cmd_rm(image, &mac_path),
+        HfsCommand::PutBoot { image, bb_file } => cmd_put_boot(image, bb_file),
+        HfsCommand::Validate { image } => cmd_validate(image),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// new
+// ---------------------------------------------------------------------------
+
+fn cmd_new(image: PathBuf, size_arg: &str, name: &str, block_size: Option<u32>) -> Result<()> {
+    let size = parse_size(size_arg)?;
+    if size < 1024 {
+        bail!("size {size} is too small for an HFS volume");
+    }
+    let block_size = match block_size {
+        Some(bs) => {
+            if bs == 0 || bs % 512 != 0 {
+                bail!("block-size must be a non-zero multiple of 512 (got {bs})");
+            }
+            bs
+        }
+        None => pick_block_size(size),
+    };
+
+    let bytes = create_blank_hfs_sized(size, block_size, name, 0, 0)
+        .map_err(|e| anyhow!("failed to format HFS volume: {e}"))?;
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(&image)
+        .with_context(|| format!("opening {} for write", image.display()))?;
+    file.write_all(&bytes)
+        .with_context(|| format!("writing {}", image.display()))?;
+    file.flush().ok();
+
+    println!(
+        "Created HFS volume {} ({} bytes, block_size={})",
+        image.display(),
+        bytes.len(),
+        block_size
+    );
+    Ok(())
+}
+
+/// Smallest 512-byte-multiple block size that keeps total_blocks <= 65535.
+fn pick_block_size(volume_bytes: u64) -> u32 {
+    let mut bs: u32 = 512;
+    while volume_bytes / bs as u64 > 65535 {
+        bs = bs.saturating_mul(2);
+        if bs == 0 {
+            return 1 << 16;
+        }
+    }
+    bs
+}
+
+fn parse_size(s: &str) -> Result<u64> {
+    let s = s.trim();
+    if s.is_empty() {
+        bail!("empty size");
+    }
+    let (num_part, mult): (&str, u64) =
+        if let Some(rest) = s.strip_suffix("KiB").or_else(|| s.strip_suffix('K')) {
+            (rest, 1024)
+        } else if let Some(rest) = s.strip_suffix("MiB").or_else(|| s.strip_suffix('M')) {
+            (rest, 1024 * 1024)
+        } else if let Some(rest) = s.strip_suffix("GiB").or_else(|| s.strip_suffix('G')) {
+            (rest, 1024 * 1024 * 1024)
+        } else if let Some(rest) = s.strip_suffix('B') {
+            (rest, 1)
+        } else {
+            (s, 1)
+        };
+    let n: u64 = num_part
+        .trim()
+        .parse()
+        .map_err(|_| anyhow!("invalid size {s:?}"))?;
+    n.checked_mul(mult)
+        .ok_or_else(|| anyhow!("size {s:?} overflows u64"))
+}
+
+// ---------------------------------------------------------------------------
+// info / ls
+// ---------------------------------------------------------------------------
+
+fn cmd_info(image: PathBuf) -> Result<()> {
+    let file = open_image_ro(&image)?;
+    let fs = HfsFilesystem::open(file, 0).map_err(|e| anyhow!("opening HFS: {e}"))?;
+    let s = fs.volume_summary();
+    println!("Volume:      {}", s.volume_name);
+    println!("Block size:  {} bytes", s.block_size);
+    println!("Total blocks:{}", s.total_blocks);
+    println!("Free blocks: {}", s.free_blocks);
+    println!("Used bytes:  {}", s.used_bytes);
+    println!("Files:       {}", s.file_count);
+    println!("Folders:     {}", s.folder_count);
+    Ok(())
+}
+
+fn cmd_ls(image: PathBuf, path: &str) -> Result<()> {
+    let file = open_image_ro(&image)?;
+    let mut fs = HfsFilesystem::open(file, 0).map_err(|e| anyhow!("opening HFS: {e}"))?;
+    let entry = resolve_path(&mut fs, path)?;
+    if !entry.is_directory() {
+        bail!("not a directory: {path}");
+    }
+    let children = fs
+        .list_directory(&entry)
+        .map_err(|e| anyhow!("list_directory: {e}"))?;
+    for c in children {
+        let kind = if c.is_directory() { "DIR " } else { "FILE" };
+        let t = c.type_code.as_deref().unwrap_or("    ");
+        let cr = c.creator_code.as_deref().unwrap_or("    ");
+        println!("{kind}  {:>10}  {t} {cr}  {}", c.size, c.name);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// put / get / rm
+// ---------------------------------------------------------------------------
+
+fn cmd_put(
+    image: PathBuf,
+    host_file: Option<PathBuf>,
+    mac_path: &str,
+    type_code: &str,
+    creator: &str,
+    zero_pad: Option<u64>,
+    force: bool,
+) -> Result<()> {
+    let (parent_path, name) = split_mac_path(mac_path)?;
+    if name.is_empty() {
+        bail!("destination path has no filename");
+    }
+
+    let file = open_image_rw(&image)?;
+    let mut fs = HfsFilesystem::open(file, 0).map_err(|e| anyhow!("opening HFS: {e}"))?;
+
+    let parent = resolve_path(&mut fs, &parent_path)?;
+    if !parent.is_directory() {
+        bail!("parent is not a directory: {parent_path}");
+    }
+
+    // Duplicate check (so we can honor --force consistently).
+    let existing = fs
+        .list_directory(&parent)
+        .map_err(|e| anyhow!("list_directory: {e}"))?
+        .into_iter()
+        .find(|e| e.name == name);
+    if let Some(ref e) = existing {
+        if !force {
+            bail!("{mac_path} already exists (pass --force to overwrite)");
+        }
+        fs.delete_entry(&parent, e)
+            .map_err(|e| anyhow!("delete existing: {e}"))?;
+    }
+
+    let options = CreateFileOptions {
+        type_code: Some(type_code.to_string()),
+        creator_code: Some(creator.to_string()),
+        ..Default::default()
+    };
+
+    if let Some(n) = zero_pad {
+        let mut zr = ZeroReader { remaining: n };
+        fs.create_file(&parent, &name, &mut zr, n, &options)
+            .map_err(|e| anyhow!("create_file: {e}"))?;
+    } else {
+        let host = host_file.ok_or_else(|| {
+            anyhow!("either provide a host file or use --zero-pad N to pre-allocate zeros")
+        })?;
+        let meta = std::fs::metadata(&host).with_context(|| format!("stat {}", host.display()))?;
+        let len = meta.len();
+        let mut hf =
+            std::fs::File::open(&host).with_context(|| format!("open {}", host.display()))?;
+        fs.create_file(&parent, &name, &mut hf, len, &options)
+            .map_err(|e| anyhow!("create_file: {e}"))?;
+    }
+
+    fs.sync_metadata()
+        .map_err(|e| anyhow!("sync_metadata: {e}"))?;
+    Ok(())
+}
+
+fn cmd_get(image: PathBuf, mac_path: &str, host_file: PathBuf) -> Result<()> {
+    let file = open_image_ro(&image)?;
+    let mut fs = HfsFilesystem::open(file, 0).map_err(|e| anyhow!("opening HFS: {e}"))?;
+    let entry = resolve_path(&mut fs, mac_path)?;
+    if entry.is_directory() {
+        bail!("{mac_path} is a directory");
+    }
+    let mut out = std::fs::File::create(&host_file)
+        .with_context(|| format!("creating {}", host_file.display()))?;
+    fs.write_file_to(&entry, &mut out)
+        .map_err(|e| anyhow!("write_file_to: {e}"))?;
+    Ok(())
+}
+
+fn cmd_rm(image: PathBuf, mac_path: &str) -> Result<()> {
+    let (parent_path, name) = split_mac_path(mac_path)?;
+    if name.is_empty() {
+        bail!("path has no filename");
+    }
+    let file = open_image_rw(&image)?;
+    let mut fs = HfsFilesystem::open(file, 0).map_err(|e| anyhow!("opening HFS: {e}"))?;
+    let parent = resolve_path(&mut fs, &parent_path)?;
+    let children = fs
+        .list_directory(&parent)
+        .map_err(|e| anyhow!("list_directory: {e}"))?;
+    let entry = children
+        .into_iter()
+        .find(|c| c.name == name)
+        .ok_or_else(|| anyhow!("not found: {mac_path}"))?;
+    fs.delete_entry(&parent, &entry)
+        .map_err(|e| anyhow!("delete_entry: {e}"))?;
+    fs.sync_metadata()
+        .map_err(|e| anyhow!("sync_metadata: {e}"))?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// put-boot / validate
+// ---------------------------------------------------------------------------
+
+fn cmd_put_boot(image: PathBuf, bb_file: PathBuf) -> Result<()> {
+    let bb = std::fs::read(&bb_file).with_context(|| format!("reading {}", bb_file.display()))?;
+    if bb.len() > 1024 {
+        bail!(
+            "boot block source is {} bytes; HFS boot region is 1024 bytes max",
+            bb.len()
+        );
+    }
+    let mut file = OpenOptions::new()
+        .write(true)
+        .read(true)
+        .open(&image)
+        .with_context(|| format!("opening {} for write", image.display()))?;
+    file.seek(SeekFrom::Start(0))?;
+    file.write_all(&bb)?;
+    file.flush()?;
+    Ok(())
+}
+
+fn cmd_validate(image: PathBuf) -> Result<()> {
+    let mut file = open_image_ro(&image)?;
+    validate_hfs_integrity(&mut file, 0, &mut |line| println!("{line}"))
+        .map_err(|e| anyhow!("{e}"))?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+fn open_image_ro(path: &PathBuf) -> Result<std::fs::File> {
+    std::fs::File::open(path).with_context(|| format!("opening {}", path.display()))
+}
+
+fn open_image_rw(path: &PathBuf) -> Result<std::fs::File> {
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .with_context(|| format!("opening {} for read/write", path.display()))
+}
+
+fn split_mac_path(p: &str) -> Result<(String, String)> {
+    let normalized = p.trim_end_matches('/');
+    if normalized.is_empty() || normalized == "/" {
+        return Ok(("/".into(), String::new()));
+    }
+    let (parent, name) = match normalized.rsplit_once('/') {
+        Some((par, n)) => (par, n),
+        None => ("", normalized),
+    };
+    let parent = if parent.is_empty() {
+        "/".into()
+    } else {
+        parent.to_string()
+    };
+    Ok((parent, name.to_string()))
+}
+
+fn resolve_path<R: Read + Seek + Send>(
+    fs: &mut HfsFilesystem<R>,
+    path: &str,
+) -> Result<crate::fs::entry::FileEntry> {
+    let mut current = fs.root().map_err(|e| anyhow!("root: {e}"))?;
+    let trimmed = path.trim_start_matches('/').trim_end_matches('/');
+    if trimmed.is_empty() {
+        return Ok(current);
+    }
+    for component in trimmed.split('/') {
+        if component.is_empty() {
+            continue;
+        }
+        let children = fs
+            .list_directory(&current)
+            .map_err(|e| anyhow!("list_directory: {e}"))?;
+        let next = children
+            .into_iter()
+            .find(|c| c.name == component)
+            .ok_or_else(|| anyhow!("path component not found: {component}"))?;
+        current = next;
+    }
+    Ok(current)
+}
+
+/// Adapter that pretends to be a file of `remaining` zero bytes.
+struct ZeroReader {
+    remaining: u64,
+}
+
+impl Read for ZeroReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.remaining == 0 {
+            return Ok(0);
+        }
+        let n = buf.len().min(self.remaining as usize);
+        for b in &mut buf[..n] {
+            *b = 0;
+        }
+        self.remaining -= n as u64;
+        Ok(n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_size_bytes() {
+        assert_eq!(parse_size("819200").unwrap(), 819200);
+        assert_eq!(parse_size("800K").unwrap(), 819200);
+        assert_eq!(parse_size("800KiB").unwrap(), 819200);
+        assert_eq!(parse_size("5M").unwrap(), 5 * 1024 * 1024);
+        assert_eq!(parse_size("1G").unwrap(), 1024 * 1024 * 1024);
+        assert!(parse_size("").is_err());
+        assert!(parse_size("nope").is_err());
+    }
+
+    #[test]
+    fn split_mac_path_cases() {
+        assert_eq!(split_mac_path("/foo").unwrap(), ("/".into(), "foo".into()));
+        assert_eq!(
+            split_mac_path("/foo/bar.txt").unwrap(),
+            ("/foo".into(), "bar.txt".into())
+        );
+        assert_eq!(split_mac_path("/").unwrap(), ("/".into(), String::new()));
+    }
+
+    #[test]
+    fn pick_block_size_floppy_and_large() {
+        assert_eq!(pick_block_size(819_200), 512);
+        // 60 MiB needs > 512: 60M/512 = 122880 > 65535, so bs jumps to 1024.
+        assert_eq!(pick_block_size(60 * 1024 * 1024), 1024);
+    }
+}

--- a/src/fs/efs.rs
+++ b/src/fs/efs.rs
@@ -543,11 +543,15 @@ impl<R: Read + Seek> EfsFilesystem<R> {
 /// pulling them into the writable surface.
 ///
 /// Bitmap convention used here: 1 bit per disk block over the range
-/// `[0 .. bmsize * 8)`. **Set bit = block in use**, cleared bit = free.
-/// The bitmap covers the entire volume, with inode-table and reserved
-/// regions force-marked in-use by mkfs_efs; allocation simply respects
-/// the existing 1-bits. Block 0 (volume header) and block 1 (primary
-/// SB) are also marked in-use by convention.
+/// `[0 .. bmsize * 8)`. **Set bit = block FREE**, cleared bit = in use.
+/// This matches the convention used by IRIX `mkfs_efs` on real disks
+/// (verified against a 2 GB SCSI volume — 97%+ of inode-claimed data
+/// blocks have their bitmap bit cleared, ~tfree blocks have it set).
+/// It is opposite to the convention used by FAT/NTFS/exFAT but matches
+/// our Amiga filesystems (AFFS/PFS3/SFS). The bitmap covers the entire
+/// volume, with inode-table and reserved regions force-marked in-use
+/// (bit=0) by mkfs_efs; allocation flips bits from 1→0. Block 0
+/// (volume header) and block 1 (primary SB) are marked in-use (bit=0).
 #[allow(dead_code)] // wired up across EFS Slices 3–8
 impl<R: Read + Write + Seek> EfsFilesystem<R> {
     /// Lazy-load the free-space bitmap into `staged_bitmap` and return
@@ -650,8 +654,9 @@ impl<R: Read + Write + Seek> EfsFilesystem<R> {
             }
             let byte = (bit / 8) as usize;
             let bit_in_byte = 7 - (bit % 8); // big-endian bit order, MSB first
-            let in_use = (bm[byte] >> bit_in_byte) & 1 == 1;
-            if in_use {
+                                             // set bit = FREE on real IRIX EFS, so a free block is bit==1.
+            let free = (bm[byte] >> bit_in_byte) & 1 == 1;
+            if !free {
                 run_start = None;
                 run_len = 0;
             } else {
@@ -663,11 +668,11 @@ impl<R: Read + Write + Seek> EfsFilesystem<R> {
                 }
                 if run_len >= want_blocks {
                     let start = run_start.unwrap();
-                    // Mark bits [start..start+want_blocks) as in-use.
+                    // Mark bits [start..start+want_blocks) as in-use (clear).
                     for b in start..start + want_blocks {
                         let by = (b / 8) as usize;
                         let bb = 7 - (b % 8);
-                        bm[by] |= 1 << bb;
+                        bm[by] &= !(1u8 << bb);
                     }
                     return Ok(EfsExtent {
                         magic: 0,
@@ -685,6 +690,7 @@ impl<R: Read + Write + Seek> EfsFilesystem<R> {
 
     /// Mark a previously-allocated extent as free in the in-memory
     /// bitmap. Caller writes the bitmap back via `write_bitmap`.
+    /// Convention: set bit = free.
     pub(crate) fn free_extent_in_bitmap(bm: &mut [u8], ext: &EfsExtent) {
         let start = ext.bn;
         let len = ext.length as u32;
@@ -694,7 +700,7 @@ impl<R: Read + Write + Seek> EfsFilesystem<R> {
                 break;
             }
             let bb = 7 - (b % 8);
-            bm[by] &= !(1u8 << bb);
+            bm[by] |= 1u8 << bb;
         }
     }
 
@@ -1447,12 +1453,13 @@ fn repair_efs<R: Read + Write + Seek + Send>(
             continue;
         }
         let bb = 7 - (blk % 8);
-        bm[by] |= 1 << bb;
+        // set bit = free; mark as in-use by CLEARING the bit.
+        bm[by] &= !(1 << bb);
         bitmap_fixes += 1;
     }
     if bitmap_fixes > 0 {
         report.fixes_applied.push(format!(
-            "Bitmap: set {bitmap_fixes} missing in-use bit(s) for inode-claimed blocks"
+            "Bitmap: cleared {bitmap_fixes} stray free bit(s) for inode-claimed blocks"
         ));
     }
 
@@ -2598,14 +2605,18 @@ mod tests {
             checksum: 0,
         };
         sb.write_into(&mut img[sb_off..sb_off + EFS_SUPERBLOCK_SIZE]);
-        // Mark blocks 0, 1 (boot, primary SB), 2 (bitmap), 18..20 (CG 0
-        // inode region) as in-use. Leave everything else free.
+        // Bitmap convention: set bit = free, clear bit = in-use. Fill
+        // the bitmap region with 0xFF (all free), then CLEAR bits for
+        // boot, primary SB, bitmap, CG 0 inode region, and last block.
         let bm_off = 2 * 512;
+        for b in 0..sb.bmsize as usize {
+            img[bm_off + b] = 0xFF;
+        }
         let in_use_blocks = [0u32, 1, 2, 18, 19, total_blocks - 1];
         for b in in_use_blocks {
             let by = (b / 8) as usize;
             let bb = 7 - (b % 8);
-            img[bm_off + by] |= 1 << bb;
+            img[bm_off + by] &= !(1 << bb);
         }
         img
     }
@@ -2616,10 +2627,10 @@ mod tests {
         let mut fs = EfsFilesystem::open(Cursor::new(img), 0).expect("open");
         let bm = fs.read_bitmap().expect("read bitmap");
         assert_eq!(bm.len(), fs.sb.bmsize as usize);
-        // Block 0 bit must be set; block 100 (well inside the free
-        // region of the synthetic) must be clear.
-        assert!(bm[0] & 0b1000_0000 != 0, "block 0 must be marked in-use");
-        assert!(bm[100 / 8] & (1 << (7 - (100 % 8))) == 0, "block 100 free");
+        // Convention: set bit = free. Block 0 (boot) is in-use so bit
+        // is clear; block 100 (inside free region) has bit set.
+        assert!(bm[0] & 0b1000_0000 == 0, "block 0 must be marked in-use");
+        assert!(bm[100 / 8] & (1 << (7 - (100 % 8))) != 0, "block 100 free");
         // Round-trip: write back and re-read; expect identical bytes.
         let mut bm2 = bm.clone();
         bm2[5] = 0xFF;
@@ -2639,11 +2650,12 @@ mod tests {
         // (block 19 is in-use; 20..23 are free).
         assert_eq!(ext.bn, 20);
         assert_eq!(ext.length, 4);
-        // The bits should now read as in-use.
+        // The bits should now read as in-use (set bit = free, so
+        // in-use means bit is cleared).
         for b in 20..24 {
             let by = (b / 8) as usize;
             let bb = 7 - (b % 8);
-            assert!(bm[by] & (1 << bb) != 0, "block {b} not marked");
+            assert!(bm[by] & (1 << bb) == 0, "block {b} not marked");
         }
         // A second alloc starts past the run we just took.
         let ext2 = EfsFilesystem::<Cursor<Vec<u8>>>::alloc_contiguous_in_bitmap(&mut bm, 2, 20)
@@ -2655,9 +2667,10 @@ mod tests {
     fn alloc_contiguous_errors_when_no_run_fits() {
         // 256-bit bitmap with everything in-use except a single block
         // at index 50 — request for 4 contiguous blocks must fail.
-        let mut bm = vec![0xFFu8; 32];
+        // set bit = free; start fully in-use (all zeros) then set bit 50.
+        let mut bm = vec![0u8; 32];
         let b = 50usize;
-        bm[b / 8] &= !(1 << (7 - (b % 8)));
+        bm[b / 8] |= 1 << (7 - (b % 8));
         let err = EfsFilesystem::<Cursor<Vec<u8>>>::alloc_contiguous_in_bitmap(&mut bm, 4, 0)
             .expect_err("expected DiskFull");
         assert!(matches!(err, FilesystemError::DiskFull(_)), "got {err:?}");
@@ -2665,22 +2678,19 @@ mod tests {
 
     #[test]
     fn free_extent_returns_blocks_to_pool() {
+        // Start fully in-use (set bit = free; all zeros = all in-use).
         let mut bm = vec![0u8; 32];
-        // Mark blocks 8..16 in-use.
         let ext = EfsExtent {
             magic: 0,
             bn: 8,
             length: 8,
             offset: 0,
         };
-        for b in ext.bn..ext.bn + ext.length as u32 {
-            bm[(b / 8) as usize] |= 1 << (7 - (b % 8));
-        }
         EfsFilesystem::<Cursor<Vec<u8>>>::free_extent_in_bitmap(&mut bm, &ext);
         for b in ext.bn..ext.bn + ext.length as u32 {
             let by = (b / 8) as usize;
             let bb = 7 - (b % 8);
-            assert!(bm[by] & (1 << bb) == 0, "block {b} still in-use after free");
+            assert!(bm[by] & (1 << bb) != 0, "block {b} still in-use after free");
         }
     }
 
@@ -2787,12 +2797,15 @@ mod tests {
         };
         sb.write_into(&mut img[sb_off..sb_off + EFS_SUPERBLOCK_SIZE]);
 
-        // Bitmap: mark in-use bits.
+        // Bitmap: set bit = free. Fill with 0xFF, then clear in-use bits.
         let bm_off = 2 * 512;
+        for b in 0..sb.bmsize as usize {
+            img[bm_off + b] = 0xFF;
+        }
         for b in [0u32, 1, 2, 18, 19, 25, total_blocks - 1] {
             let by = (b / 8) as usize;
             let bb = 7 - (b % 8);
-            img[bm_off + by] |= 1 << bb;
+            img[bm_off + by] &= !(1 << bb);
         }
 
         // Root inode (2) at byte (firstcg=18)*512 + 2*128.
@@ -3074,14 +3087,15 @@ mod tests {
             .expect("create");
         EditableFilesystem::sync_metadata(&mut fs).expect("sync");
 
-        // Reach into the bitmap and clear the bit for the file's
-        // data block — fsck should flag it.
+        // Reach into the bitmap and SET the bit for the file's data
+        // block (set bit = free), forging a "free but inode-claimed"
+        // corruption — fsck should flag it as BitmapMissingAllocation.
         let file_ino = fs.read_inode(entry.location as u32).expect("ino");
         let data_blk = file_ino.extents[0].bn;
         let mut bm = fs.read_bitmap().expect("bm");
         let by = (data_blk / 8) as usize;
         let bb = 7 - (data_blk % 8);
-        bm[by] &= !(1u8 << bb);
+        bm[by] |= 1u8 << bb;
         fs.write_bitmap(&bm).expect("write bm");
 
         let before = super::super::efs_fsck::fsck_efs(&mut fs).expect("fsck");

--- a/src/fs/efs.rs
+++ b/src/fs/efs.rs
@@ -2,9 +2,15 @@
 //!
 //! Implements Steps 3 and 4 of the SGI Filesystem plan: superblock parsing,
 //! inode lookup, directory listing (recursive), file reads via inline
-//! extents, streaming writes, and symlink-target resolution. EFS has no
-//! indirect blocks — every file is bounded by 12 direct extents (max
-//! 12 * 16 MiB = 192 MiB per file).
+//! extents, streaming writes, and symlink-target resolution.
+//!
+//! EFS stores up to 12 extents inline in the inode. When a file needs more
+//! than 12 extents, EFS switches to **indirect** mode: the inode's extent
+//! slots no longer describe data, they describe runs of disk blocks that
+//! themselves contain arrays of `efs_extent` records (64 per 512-byte
+//! block). `numextents` is the total data-extent count; `extents[0].offset`
+//! is hijacked to hold `direxts`, the number of inode slots actually used
+//! to point at indirect blocks. See Linux `fs/efs/inode.c::efs_map_block`.
 //!
 //! References:
 //! - `~/xfs-efs/refs/efs-linux-5.15/efs/` — Linux kernel v5.15 EFS sources.
@@ -417,6 +423,14 @@ impl<R: Read + Seek> EfsFilesystem<R> {
     /// privacy of `reader`.
     pub fn reader_into_inner(self) -> R {
         self.reader
+    }
+
+    pub(crate) fn raw_reader_mut(&mut self) -> &mut R {
+        &mut self.reader
+    }
+
+    pub(crate) fn partition_offset_value(&self) -> u64 {
+        self.partition_offset
     }
 
     /// Read the bitmap via the read-only path. Used by fsck.
@@ -1894,9 +1908,104 @@ impl<R: Read + Seek + Send> Filesystem for EfsFilesystem<R> {
     }
 }
 
-/// Walk the inline extents of `inode` and return up to `max_bytes` of file
-/// data. EFS has no indirect blocks: a file is bounded by 12 extents and the
-/// inode's `di_size` is the authoritative file length.
+/// Resolve an inode's data extents, handling both direct and indirect mode.
+///
+/// Direct mode (`numextents <= 12`): the inode's extent array holds data
+/// extents directly. Indirect mode (`numextents > 12`): `extents[0].offset`
+/// stores `direxts`, the number of inode slots that point at runs of
+/// indirect blocks; each indirect block packs up to 64 data-extent records.
+/// Returns the data extents in file (logical) order.
+pub(crate) fn resolve_data_extents<R: Read + Seek>(
+    reader: &mut R,
+    partition_offset: u64,
+    inode: &EfsInode,
+) -> Result<Vec<EfsExtent>, FilesystemError> {
+    let total = inode.numextents as usize;
+    if total <= EFS_DIRECTEXTENTS {
+        let mut out: Vec<EfsExtent> = inode.extents.iter().take(total).copied().collect();
+        out.sort_by_key(|e| e.offset);
+        return Ok(out);
+    }
+    let direxts = inode.extents[0].offset as usize;
+    if direxts == 0 || direxts > EFS_DIRECTEXTENTS {
+        return Err(FilesystemError::InvalidData(format!(
+            "EFS inode {} indirect mode: bad direxts={direxts} (numextents={total})",
+            inode.inum
+        )));
+    }
+    const EXTS_PER_BLOCK: usize = (EFS_BLOCKSIZE as usize) / 8;
+    let mut out: Vec<EfsExtent> = Vec::with_capacity(total);
+    let mut block_buf = [0u8; EFS_BLOCKSIZE as usize];
+    'collect: for dirslot in 0..direxts {
+        let ind = inode.extents[dirslot];
+        for blk in 0..ind.length as u32 {
+            let bn = ind.bn + blk;
+            read_at_aligned(
+                reader,
+                partition_offset + bn as u64 * EFS_BLOCKSIZE,
+                EFS_BLOCKSIZE,
+                &mut block_buf,
+            )?;
+            for slot in 0..EXTS_PER_BLOCK {
+                let off = slot * 8;
+                let raw: &[u8; 8] = (&block_buf[off..off + 8]).try_into().unwrap();
+                let ext = EfsExtent::parse(raw);
+                if ext.magic != 0 {
+                    return Err(FilesystemError::InvalidData(format!(
+                        "EFS inode {} indirect extent slot {slot} in block {bn}: bad magic 0x{:02X}",
+                        inode.inum, ext.magic
+                    )));
+                }
+                out.push(ext);
+                if out.len() == total {
+                    break 'collect;
+                }
+            }
+        }
+    }
+    if out.len() != total {
+        return Err(FilesystemError::InvalidData(format!(
+            "EFS inode {} indirect: collected {} of {total} extents",
+            inode.inum,
+            out.len()
+        )));
+    }
+    out.sort_by_key(|e| e.offset);
+    Ok(out)
+}
+
+/// Like `resolve_data_extents`, but also returns the indirect-block extents
+/// (the disk regions used to hold extent records in indirect mode). The
+/// `(data, indirect)` split lets callers like fsck and the resize bitmap
+/// walker account for every disk block claimed by an inode — both file
+/// content and the indirect-extent index blocks themselves. In direct
+/// mode the indirect vector is empty.
+pub(crate) fn resolve_owned_extents<R: Read + Seek>(
+    reader: &mut R,
+    partition_offset: u64,
+    inode: &EfsInode,
+) -> Result<(Vec<EfsExtent>, Vec<EfsExtent>), FilesystemError> {
+    if (inode.numextents as usize) <= EFS_DIRECTEXTENTS {
+        return Ok((
+            resolve_data_extents(reader, partition_offset, inode)?,
+            Vec::new(),
+        ));
+    }
+    let direxts = inode.extents[0].offset as usize;
+    if direxts == 0 || direxts > EFS_DIRECTEXTENTS {
+        return Err(FilesystemError::InvalidData(format!(
+            "EFS inode {} indirect mode: bad direxts={direxts}",
+            inode.inum
+        )));
+    }
+    let indirect: Vec<EfsExtent> = inode.extents.iter().take(direxts).copied().collect();
+    let data = resolve_data_extents(reader, partition_offset, inode)?;
+    Ok((data, indirect))
+}
+
+/// Walk the data extents of `inode` (direct or indirect) and return up to
+/// `max_bytes` of file data. The inode's `di_size` is the authoritative
+/// file length.
 fn read_inode_data<R: Read + Seek>(
     reader: &mut R,
     partition_offset: u64,
@@ -1909,13 +2018,7 @@ fn read_inode_data<R: Read + Seek>(
     if want == 0 {
         return Ok(out);
     }
-    let mut extents: Vec<EfsExtent> = inode
-        .extents
-        .iter()
-        .take(inode.numextents as usize)
-        .copied()
-        .collect();
-    extents.sort_by_key(|e| e.offset);
+    let extents = resolve_data_extents(reader, partition_offset, inode)?;
     let mut block_buf = [0u8; EFS_BLOCKSIZE as usize];
     'outer: for ext in &extents {
         for i in 0..ext.length as u32 {
@@ -1954,13 +2057,7 @@ fn stream_inode_data<R: Read + Seek>(
     if size == 0 {
         return Ok(0);
     }
-    let mut extents: Vec<EfsExtent> = inode
-        .extents
-        .iter()
-        .take(inode.numextents as usize)
-        .copied()
-        .collect();
-    extents.sort_by_key(|e| e.offset);
+    let extents = resolve_data_extents(reader, partition_offset, inode)?;
 
     const CHUNK_BLOCKS: u32 = 1024 * 1024 / EFS_BLOCKSIZE as u32; // 1 MiB
     let mut buf = vec![0u8; (CHUNK_BLOCKS as usize) * EFS_BLOCKSIZE as usize];

--- a/src/fs/efs_fsck.rs
+++ b/src/fs/efs_fsck.rs
@@ -28,7 +28,8 @@ use std::collections::HashSet;
 use std::io::{Read, Seek};
 
 use super::efs::{
-    parse_dir_block, EfsFilesystem, EfsSuperblock, EFS_BLOCKSIZE, EFS_DIRECTEXTENTS_MAX,
+    parse_dir_block, resolve_owned_extents, EfsExtent, EfsFilesystem, EfsSuperblock, EFS_BLOCKSIZE,
+    EFS_DIRECTEXTENTS_MAX,
 };
 use super::filesystem::FilesystemError;
 use super::fsck::{FsckIssue, FsckResult, FsckStats, OrphanedEntry};
@@ -107,6 +108,39 @@ impl Builder {
     }
 }
 
+fn walk_extent(
+    b: &mut Builder,
+    allocated: &mut HashSet<u32>,
+    sb: &EfsSuperblock,
+    inum: u32,
+    ext: &EfsExtent,
+    label: &str,
+    idx: usize,
+) {
+    if ext.length == 0 {
+        return;
+    }
+    let end = ext.bn.saturating_add(ext.length as u32);
+    if end > sb.fs_size {
+        b.err(
+            "ExtentPastVolume",
+            format!(
+                "inode {inum} {label} extent {idx}: [{}..{}) extends past fs_size {}",
+                ext.bn, end, sb.fs_size
+            ),
+        );
+        return;
+    }
+    for blk in ext.bn..end {
+        if !allocated.insert(blk) {
+            b.err(
+                "DoubleAllocation",
+                format!("block {blk} (inode {inum} {label} extent {idx}) also allocated elsewhere"),
+            );
+        }
+    }
+}
+
 /// Run the verifier. Requires read-only access; the editable surface
 /// `R: Read + Write + Seek + Send` works fine here because all
 /// methods used are inherited from the read-only impl.
@@ -144,49 +178,34 @@ pub fn fsck_efs<R: Read + Seek>(fs: &mut EfsFilesystem<R>) -> Result<FsckResult,
         } else {
             b.files_checked += 1;
         }
-        if ino.numextents as usize > EFS_DIRECTEXTENTS_MAX {
-            b.err(
-                "TooManyExtents",
-                format!(
-                    "inode {inum} has numextents={} (max {EFS_DIRECTEXTENTS_MAX})",
-                    ino.numextents
-                ),
-            );
-        }
-        for i in 0..(ino.numextents as usize).min(EFS_DIRECTEXTENTS_MAX) {
-            let ext = ino.extents[i];
+        // Walk both data extents and (in indirect mode) the inode's
+        // indirect-block runs themselves — both occupy bitmap-tracked
+        // disk regions and both count toward this inode's allocation.
+        let pofs = fs.partition_offset_value();
+        let (data_exts, indirect_exts) =
+            match resolve_owned_extents(fs.raw_reader_mut(), pofs, &ino) {
+                Ok(pair) => pair,
+                Err(e) => {
+                    b.err("IndirectExtentReadFailed", format!("inode {inum}: {e}"));
+                    continue;
+                }
+            };
+        for (i, ext) in data_exts.iter().enumerate() {
             if ext.magic != 0 {
                 b.err(
                     "ExtentBadMagic",
                     format!(
-                        "inode {inum} extent {i}: magic=0x{:02X} (expected 0)",
+                        "inode {inum} data extent {i}: magic=0x{:02X} (expected 0)",
                         ext.magic
                     ),
                 );
             }
-            if ext.length == 0 {
-                continue;
-            }
-            let end = ext.bn.saturating_add(ext.length as u32);
-            if end > sb.fs_size {
-                b.err(
-                    "ExtentPastVolume",
-                    format!(
-                        "inode {inum} extent {i}: [{}..{}) extends past fs_size {}",
-                        ext.bn, end, sb.fs_size
-                    ),
-                );
-                continue;
-            }
-            for blk in ext.bn..end {
-                if !allocated.insert(blk) {
-                    b.err(
-                        "DoubleAllocation",
-                        format!("block {blk} allocated to inode {inum} but also to another inode"),
-                    );
-                }
-            }
+            walk_extent(&mut b, &mut allocated, &sb, inum, ext, "data", i);
         }
+        for (i, ext) in indirect_exts.iter().enumerate() {
+            walk_extent(&mut b, &mut allocated, &sb, inum, ext, "indirect-index", i);
+        }
+        let _ = EFS_DIRECTEXTENTS_MAX;
     }
 
     if let Some(bm) = bitmap {

--- a/src/fs/efs_fsck.rs
+++ b/src/fs/efs_fsck.rs
@@ -209,10 +209,11 @@ pub fn fsck_efs<R: Read + Seek>(fs: &mut EfsFilesystem<R>) -> Result<FsckResult,
     }
 
     if let Some(bm) = bitmap {
-        // Cross-check: every "in use" inode-claimed block should have
-        // its bitmap bit set. (We don't check the reverse — the bitmap
-        // legitimately marks inode-table + reserved regions as in-use
-        // and those don't show up in inode extents.)
+        // EFS bitmap convention: set bit = FREE, clear bit = in use. So
+        // every inode-claimed block should have its bit CLEARED. (We
+        // don't check the reverse: the bitmap legitimately marks
+        // inode-table + reserved regions as in-use (bit=0) too, and
+        // those don't show up in inode extents.)
         for blk in &allocated {
             let byte = (*blk / 8) as usize;
             if byte >= bm.len() {
@@ -227,16 +228,16 @@ pub fn fsck_efs<R: Read + Seek>(fs: &mut EfsFilesystem<R>) -> Result<FsckResult,
                 continue;
             }
             let bit = 7 - (blk % 8);
-            if bm[byte] & (1 << bit) == 0 {
+            if bm[byte] & (1 << bit) != 0 {
                 b.err(
                     "BitmapMissingAllocation",
-                    format!("inode-allocated block {blk} is not marked in-use in bitmap"),
+                    format!("inode-allocated block {blk} is marked free in bitmap"),
                 );
             }
         }
         let set_bits: u32 = bm.iter().map(|b| b.count_ones()).sum();
         b.extra
-            .push(("bitmap_set_bits".into(), set_bits.to_string()));
+            .push(("bitmap_free_bits".into(), set_bits.to_string()));
     } else {
         b.warn("BitmapReadFailed", "could not read bitmap".into());
     }
@@ -427,12 +428,17 @@ mod tests {
         };
         sb.write_into(&mut img[sb_off..sb_off + super::super::efs::EFS_SUPERBLOCK_SIZE]);
 
-        // Bitmap: blocks 0/1/2 + 18/19 (CG 0 inode region) + 25 (root dir) + last block.
+        // Bitmap convention: set bit = free. Fill with 0xFF (all free)
+        // then CLEAR bits for in-use blocks: 0/1/2, 18/19 (CG 0 inode
+        // region), 25 (root dir), and last block.
         let bm_off = 2 * 512;
+        for b in 0..sb.bmsize as usize {
+            img[bm_off + b] = 0xFF;
+        }
         for b in [0u32, 1, 2, 18, 19, 25, total_blocks - 1] {
             let by = (b / 8) as usize;
             let bb = 7 - (b % 8);
-            img[bm_off + by] |= 1 << bb;
+            img[bm_off + by] &= !(1 << bb);
         }
         // Mirror the primary SB into the replica slot.
         let replica_off = (total_blocks as usize - 1) * 512;

--- a/src/fs/efs_resize.rs
+++ b/src/fs/efs_resize.rs
@@ -693,8 +693,14 @@ pub fn compute_conservative_floor<R: Read + Seek>(
         if inode_block_end > highest {
             highest = inode_block_end;
         }
-        for i in 0..(ino.numextents as usize).min(EFS_DIRECTEXTENTS_MAX) {
-            let ext = ino.extents[i];
+        // For indirect-mode inodes (numextents > 12) the inode's own
+        // extent slots describe indirect index blocks rather than data;
+        // resolve_owned_extents returns both sets so the shrink floor
+        // covers every block that must survive truncation.
+        let pofs = fs.partition_offset_value();
+        let (data_exts, indirect_exts) =
+            super::efs::resolve_owned_extents(fs.raw_reader_mut(), pofs, &ino)?;
+        for ext in data_exts.iter().chain(indirect_exts.iter()) {
             if ext.length == 0 {
                 continue;
             }
@@ -704,6 +710,7 @@ pub fn compute_conservative_floor<R: Read + Seek>(
             }
         }
     }
+    let _ = EFS_DIRECTEXTENTS_MAX;
     Ok(highest)
 }
 

--- a/src/fs/efs_resize.rs
+++ b/src/fs/efs_resize.rs
@@ -133,7 +133,8 @@ pub fn grow_efs<R: Read + Write + Seek>(
                     break;
                 }
                 let bb = 7 - (blk % 8);
-                if bm[by] & (1u8 << bb) != 0 {
+                // set bit = free, so in-use means the bit is CLEAR.
+                if bm[by] & (1u8 << bb) == 0 {
                     return Err(FilesystemError::InvalidData(format!(
                         "EFS grow: cannot append new CG at block {cg_start}: \
                          inode-region block {blk} is already in use by a file. \
@@ -141,7 +142,7 @@ pub fn grow_efs<R: Read + Write + Seek>(
                          for now, fsck the volume and retry with a smaller increase."
                     )));
                 }
-                bm[by] |= 1u8 << bb; // reserve
+                bm[by] &= !(1u8 << bb); // reserve (mark in-use)
             }
         }
     }
@@ -158,7 +159,8 @@ pub fn grow_efs<R: Read + Write + Seek>(
     };
 
     // Mark the new tail blocks as free in the bitmap. Per the doc,
-    // any stale bits left over from prior shrink rounds get cleared.
+    // any stale bits left over from prior shrink rounds get reset to
+    // the "free" state. Convention: set bit = free.
     {
         let bm = fs.staged_bitmap_mut()?;
         for blk in old_size..new_size_blocks {
@@ -167,7 +169,7 @@ pub fn grow_efs<R: Read + Write + Seek>(
                 break;
             }
             let bb = 7 - (blk % 8);
-            bm[by] &= !(1u8 << bb);
+            bm[by] |= 1u8 << bb;
         }
     }
 
@@ -206,7 +208,8 @@ pub fn grow_efs<R: Read + Write + Seek>(
                     break;
                 }
                 let bb = 7 - (blk % 8);
-                bm[by] |= 1u8 << bb;
+                // set bit = free; mark inode region as in-use by clearing.
+                bm[by] &= !(1u8 << bb);
             }
         }
     }
@@ -310,20 +313,20 @@ fn relocate_bitmap<R: Read + Write + Seek>(
         new_bmsize_sectors
     ));
 
-    // Free old bitmap blocks.
+    // Free old bitmap blocks. Convention: set bit = free.
     for blk in old_bmblock..old_bmblock + old_bmsize_sectors {
         let by = (blk / 8) as usize;
         if by >= bm.len() {
             break;
         }
         let bb = 7 - (blk % 8);
-        bm[by] &= !(1u8 << bb);
+        bm[by] |= 1u8 << bb;
     }
 
     // Expand the in-memory buffer to the new bitmap size. New bytes
-    // default to 0 (all blocks free); the grow path's tail loop and
-    // CG-append step will set the appropriate bits before sync.
-    bm.resize(new_bmsize_bytes as usize, 0);
+    // default to 0xFF (all blocks free); the grow path's tail loop and
+    // CG-append step will clear bits for in-use blocks before sync.
+    bm.resize(new_bmsize_bytes as usize, 0xFF);
 
     let mut new_sb = sb.clone();
     new_sb.bmblock = new_bmblock;
@@ -375,10 +378,10 @@ pub fn shrink_efs_conservative<R: Read + Write + Seek>(
         )));
     }
 
-    // Clear the bits for blocks [new_size_blocks..old_size) in the
-    // bitmap (they're now outside the volume). The bitmap itself
-    // stays at its current location and keeps its current size — the
-    // surplus bits past new_size_blocks are simply unused.
+    // Reset the bits for blocks [new_size_blocks..old_size) in the
+    // bitmap to "free" (they're now outside the volume; mark them
+    // consistently so a later grow doesn't observe stray in-use bits).
+    // Convention: set bit = free.
     {
         let bm = fs.staged_bitmap_mut()?;
         for blk in new_size_blocks..old_size {
@@ -387,7 +390,7 @@ pub fn shrink_efs_conservative<R: Read + Write + Seek>(
                 break;
             }
             let bb = 7 - (blk % 8);
-            bm[by] &= !(1u8 << bb);
+            bm[by] |= 1u8 << bb;
         }
     }
 
@@ -757,12 +760,17 @@ mod tests {
         };
         sb.write_into(&mut img[sb_off..sb_off + EFS_SUPERBLOCK_SIZE]);
 
-        // Bitmap: mark reserved-region bits.
+        // Bitmap: set bit = free, clear bit = in use (matches real
+        // IRIX EFS). Pre-fill `bmsize` bytes with 0xFF (all free), then
+        // CLEAR bits for reserved/in-use blocks.
         let bm_off = 2 * 512;
+        for b in 0..sb.bmsize as usize {
+            img[bm_off + b] = 0xFF;
+        }
         for b in [0u32, 1, 2, 3, 4, 18, 19, 25] {
             let by = (b / 8) as usize;
             let bb = 7 - (b % 8);
-            img[bm_off + by] |= 1 << bb;
+            img[bm_off + by] &= !(1 << bb);
         }
         // Root inode (2) — same shape as the efs.rs synthetic tests.
         let ino2_off = 18 * 512 + 2 * 128;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod backup;
 pub mod bulk_buf_reader;
+pub mod cli;
 pub mod clonezilla;
 pub mod device;
 pub mod error;

--- a/tests/cli_hfs.rs
+++ b/tests/cli_hfs.rs
@@ -1,0 +1,162 @@
+//! End-to-end test for the `api hfs` CLI surface. Drives the
+//! `rusty-backup-cli` binary against scratch images in a tempdir.
+//!
+//! These are deliberately black-box tests: they exercise the same code
+//! path scripted consumers (e.g. the lbmactwo build pipeline) hit, so
+//! grammar or argument-shape regressions surface here before they
+//! reach those callers.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn cli_bin() -> PathBuf {
+    // Cargo sets CARGO_BIN_EXE_<name> for every [[bin]] target in scope.
+    PathBuf::from(env!("CARGO_BIN_EXE_rusty-backup-cli"))
+}
+
+fn run(args: &[&str]) -> std::process::Output {
+    let out = Command::new(cli_bin())
+        .args(args)
+        .output()
+        .expect("spawn rusty-backup-cli");
+    if !out.status.success() {
+        panic!(
+            "command {args:?} failed: status={:?}\nstdout:\n{}\nstderr:\n{}",
+            out.status,
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+    out
+}
+
+#[test]
+fn hfs_round_trip_put_get_rm() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let img = dir.path().join("disk.dsk");
+    let img_s = img.to_str().unwrap();
+
+    run(&[
+        "api", "hfs", "new", img_s, "--size", "800K", "--name", "Bench",
+    ]);
+
+    let expected_size = 800 * 1024;
+    let got_size = std::fs::metadata(&img).unwrap().len();
+    assert_eq!(got_size, expected_size, "800K image should be 819200 bytes");
+
+    // Library should be able to re-open what we wrote.
+    {
+        use rusty_backup::fs::hfs::HfsFilesystem;
+        let f = std::fs::File::open(&img).unwrap();
+        let fs = HfsFilesystem::open(f, 0).expect("re-open HFS image");
+        assert_eq!(fs.volume_summary().volume_name, "Bench");
+    }
+
+    let host = dir.path().join("hello.txt");
+    std::fs::write(&host, b"hello from host\n").unwrap();
+    run(&[
+        "api",
+        "hfs",
+        "put",
+        img_s,
+        host.to_str().unwrap(),
+        "/hello.txt",
+    ]);
+
+    let back = dir.path().join("back.txt");
+    run(&[
+        "api",
+        "hfs",
+        "get",
+        img_s,
+        "/hello.txt",
+        back.to_str().unwrap(),
+    ]);
+    assert_eq!(std::fs::read(&host).unwrap(), std::fs::read(&back).unwrap());
+
+    // put-zero pre-allocation.
+    run(&[
+        "api",
+        "hfs",
+        "put-zero",
+        img_s,
+        "/Results.jsonl",
+        "4096",
+        "--type",
+        "TEXT",
+        "--creator",
+        "ttxt",
+    ]);
+    let ls = run(&["api", "hfs", "ls", img_s, "/"]);
+    let ls_text = String::from_utf8(ls.stdout).unwrap();
+    assert!(ls_text.contains("hello.txt"));
+    assert!(ls_text.contains("Results.jsonl"));
+    assert!(ls_text.contains("TEXT ttxt"));
+
+    // Remove the file and confirm.
+    run(&["api", "hfs", "rm", img_s, "/hello.txt"]);
+    let ls2 = run(&["api", "hfs", "ls", img_s, "/"]);
+    let ls2_text = String::from_utf8(ls2.stdout).unwrap();
+    assert!(!ls2_text.contains("hello.txt"));
+    assert!(ls2_text.contains("Results.jsonl"));
+
+    run(&["api", "hfs", "validate", img_s]);
+}
+
+#[test]
+fn hfs_put_boot_writes_exact_bytes_and_keeps_catalog() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let img = dir.path().join("disk.dsk");
+    let img_s = img.to_str().unwrap();
+
+    run(&[
+        "api", "hfs", "new", img_s, "--size", "800K", "--name", "BootTest",
+    ]);
+
+    let bb = dir.path().join("bb.bin");
+    let bb_data: Vec<u8> = (0..600u32).map(|i| (i % 256) as u8).collect();
+    std::fs::write(&bb, &bb_data).unwrap();
+
+    run(&["api", "hfs", "put-boot", img_s, bb.to_str().unwrap()]);
+
+    // Exactly the source bytes at offset 0, nothing beyond.
+    let img_bytes = std::fs::read(&img).unwrap();
+    assert_eq!(&img_bytes[..bb_data.len()], &bb_data[..]);
+
+    // Catalog still intact.
+    let info = run(&["api", "hfs", "info", img_s]);
+    let info_text = String::from_utf8(info.stdout).unwrap();
+    assert!(info_text.contains("BootTest"));
+}
+
+#[test]
+fn hfs_new_larger_volume_picks_appropriate_block_size() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let img = dir.path().join("scsi.dsk");
+    let img_s = img.to_str().unwrap();
+
+    run(&[
+        "api", "hfs", "new", img_s, "--size", "5M", "--name", "SCSI5MB",
+    ]);
+
+    let info = run(&["api", "hfs", "info", img_s]);
+    let info_text = String::from_utf8(info.stdout).unwrap();
+    assert!(info_text.contains("SCSI5MB"));
+}
+
+#[test]
+fn hfs_put_boot_rejects_oversize_source() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let img = dir.path().join("disk.dsk");
+    let img_s = img.to_str().unwrap();
+    run(&["api", "hfs", "new", img_s, "--size", "800K"]);
+
+    let bb = dir.path().join("oversize.bin");
+    std::fs::write(&bb, vec![0u8; 2048]).unwrap();
+
+    let out = Command::new(cli_bin())
+        .args(["api", "hfs", "put-boot", img_s, bb.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "oversize put-boot should fail");
+}


### PR DESCRIPTION
- Add CLI support, currently only api hfs commands are working to support building stuff for the mac core
- Fixed EFS file extraction & fsck
- publishing CLI