### PR TITLE
Filename parity floppy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,3 +139,33 @@ All OS-specific code lives in `src/os/`:
 - Disable UI controls during active operations to prevent conflicts.
 - Use `Result<T>` and `?` for error propagation throughout.
 - **No Unicode glyphs in UI text or log messages.** The default egui font does not include emoji or symbol glyphs (e.g. `✓ ✗ ⚠ ← → • ✖ ℹ`), so they render as blank boxes on the user's screen. Use plain ASCII alternatives instead — `OK`, `Skipped`, `Warning`, `Back`, `->`, `-`, `X`, `Info:` — for log lines, button labels, dialog text, and any other user-visible string. The only exception is content read directly from a filesystem (e.g. symlink target arrows in the optical browse view), which we render verbatim.
+
+### Pre-commit documentation sync
+
+**Before staging a commit for any user-facing change, run a quick parity pass over three surfaces and update them in the same commit if they drifted.** These have all gone stale in real-world commits — adding a filesystem driver but forgetting the README table, shipping a new container format but leaving the picker filter behind, adding a CP/M DPB but never updating the per-core matrix. The sync is cheap (usually one extra section in the diff); diagnosing the drift from a user-reported issue is expensive.
+
+The three surfaces:
+
+1. **[README.md](README.md)** — user-facing feature lists.
+   - **Image / backup formats table** (§ Compatibility) — every new wrapper / container format gets a row with extension, read/write columns, and a one-line note.
+   - **Filesystems table** — every new fs gets a row covering Browse / Edit / Shrink-expand / fsck / Notes.
+   - **MiSTer FPGA cores table** — when a new fs / container makes a previously-Partial core go end-to-end, the cell moves to **Yes** and the media-path column gains the new extensions.
+   - **Inspect tab bullet list** — when a new dialog ships (e.g. "Convert Floppy Container..."), add the bullet.
+
+2. **[docs/full_MiSTer_support_status.md](docs/full_MiSTer_support_status.md)** — per-core status matrix.
+   - The intro § "What Rusty Backup supports today" lists filesystems / containers / partition tables; add the new entry there.
+   - The per-core table further down maps each MiSTer computer core to its FS shape and Yes/Partial/No status. When you ship support for a new filesystem (or a new DPB on a multi-DPB driver like CP/M), walk this table and re-grade every core that uses that FS. The intro and table have drifted multiple times — most recently CP/M DPBs and Apple DOS 3.3 were in the intro but the per-core matrix still marked seven cores as "No".
+
+3. **`DISK_IMAGE_EXTS` in [src/model/file_types.rs](src/model/file_types.rs)** — the single source of truth for picker extension filters and OS file-association registration.
+   - Every container format the engine knows how to open should appear here so the GUI's "Open File…" picker dropdown shows it, and so Windows Explorer / macOS Finder / Linux MIME handlers route double-clicks at us.
+   - Lowercase only for new entries (the existing `GHO` / `HFV` / `GHS` uppercase variants cover a long-standing rfd quirk; we don't grow that pattern).
+   - Add a row to the `floppy_container_family_present`-style regression test so a future cleanup that drops the extension has to do it deliberately.
+
+The quick checklist when finishing a feature:
+
+- [ ] Does this add or change a filesystem / container / partition format the user can open?
+- [ ] If yes — README Image-formats / Filesystems / MiSTer-cores table updated?
+- [ ] If yes — `docs/full_MiSTer_support_status.md` intro + per-core matrix walked?
+- [ ] If a new picker-visible file extension — `DISK_IMAGE_EXTS` updated + regression test extended?
+
+If the answer to all four is "no, nothing user-visible changed," commit as normal. Otherwise the doc / picker updates land in the same commit as the code change so reviewers see the intent.

--- a/README.md
+++ b/README.md
@@ -376,11 +376,16 @@ cores) lives in [`docs/full_MiSTer_support_status.md`](docs/full_MiSTer_support_
 | **Minimig-AGA** (Amiga)        | AFFS (OFS/FFS), PFS3, SFS on RDB, ISO9660 | Floppy (`.adf`/`.adz`), HDD (`.hdf`/`.hdz`), CD |
 | **MacPlus**                    | HFS | HDD (.hda / .hfv) — 400K MFS floppy outstanding |
 | **AtariST**                    | GEMDOS (FAT12 / FAT16), MSA containers | Floppy (`.st` / `.msa`); HDD pending AHDI write-side |
-| **Apple-II**                   | ProDOS (DOS 3.3 outstanding) | `.dsk` / `.po` / `.do` / `.2mg` / `.woz` |
+| **Apple-II**                   | ProDOS + Apple DOS 3.3 | `.dsk` / `.do` / `.po` / `.2mg` / `.woz` (sector-order auto-detect) |
 | **ZX-Spectrum**                | esxDOS FAT | DivMMC / esxDOS SD; native TR-DOS / +3DOS pending |
 | **X68000** (Sharp)             | Human68k (FAT-derived) | Floppy (`.d88` / `.xdf` / `.hdm` / `.dim` — any-to-any conversion shipped), SASI HDD (`.hdf`) |
 | **Archie** (Acorn Archimedes)  | ADFS / FileCore (read) | `.adf` floppy, bare + Arculator-wrapped `.hdf` HDD |
 | **QL** (Sinclair)              | QDOS (QXL.WIN, read + write) | HDD (.win) |
+| **Amstrad CPC**                | AMSDOS + CP/M 2.2 / Plus (`amstrad_data` + `amstrad_sys` DPBs) | Floppy `.dsk` |
+| **AmstradPCW**                 | CP/M Plus (`amstrad_pcw` DPB) | Floppy `.dsk` |
+| **TatungEinstein**             | Xtal-DOS / CP/M (`einstein` DPB) | Floppy `.dsk` |
+| **Altair8800**                 | CP/M (`altair_8in` 8-inch floppy + `altair_cf` CF/HDD DPBs) | Floppy + IDE/CF |
+| **MultiComp**                  | CP/M (`multicomp` DPB) | Floppy `.dsk` |
 
 For X68000 specifically, the floppy converter lets you take an image
 in any of the four formats Sharp tooling and MiSTer cores expect — XDF

--- a/docs/full_MiSTer_support_status.md
+++ b/docs/full_MiSTer_support_status.md
@@ -45,17 +45,17 @@ Legend for the **Support** column:
 | Minimig-AGA | Commodore Amiga | Floppy, HDD, CD | OFS/FFS, PFS3, SFS (RDB) / ISO9660 | **Yes** |
 | MacPlus | Macintosh Plus | Floppy, HDD | HFS / MFS (400K floppy) | **Partial** — HFS yes; MFS 400K floppy no |
 | AtariST | Atari ST/STe | Floppy, HDD | GEMDOS = FAT12 / FAT16 | **Partial** — FAT yes; needs Atari AHDI partition table for HDD |
-| Apple-II | Apple IIe | Floppy, HDD | DOS 3.3 / ProDOS | **Partial** — ProDOS yes; DOS 3.3 no |
+| Apple-II | Apple IIe | Floppy, HDD | DOS 3.3 / ProDOS | **Yes** — ProDOS (read + edit + fsck) + Apple DOS 3.3 (read + edit on 140 KB `.dsk`/`.do`/`.po`). Sector-order auto-detect via `containers::sector_order`. |
 | ZX-Spectrum | Sinclair ZX Spectrum | Floppy, SD/HDD | TR-DOS, G+DOS, +3DOS (CP/M-like), esxDOS FAT | **Partial** — FAT (DivMMC/esxDOS) yes; native FS no |
 | X68000 | Sharp X68000 | Floppy, SASI HDD | Human68k (FAT-derived dialect) | **Partial** — floppy yes (Human68k read + Add/Delete via Sharp `.d88` container); SASI HDD partition table + Human68k partition dispatch yes; CLI parity tests cover inspect/ls on wrapped .d88 + get/put on flat; resize-on-restore deferred |
 | Archie | Acorn Archimedes | Floppy, HDD | ADFS / FileCore | **Partial** — Disc Record scan now spans the HD, E-format-floppy, and legacy-floppy candidate offsets (0xFC0/0x404/0xDC0); byte-correct against marutan.net blank pre-formatted HD samples (`blank256E.hdf`, `blank1024Eplus.hdf`) and the 8bs.com Acorn archive `arc-04.800.adf` (E-format populated); `.adf` 800K floppy + bare `.hdf` and Arculator-wrapped `.hdf` HDD container handling shipped; CLI parity tests cover inspect/ls/get on the synthetic E-format fixture; root-directory lookup via FSM indirect-disc-address still pending (dr.root encoding mystery + non-blank HD reference both required); ADFS write path parked behind the FSM walker |
 | QL | Sinclair QL | Microdrive, HDD | QDOS (QXL.WIN) | **Partial** — QXL.WIN HDD read + write end-to-end (byte-correct against kilgus + smsqe MiSTer samples; write path validated against headless sQLux oracle — rb-cli put → SuperBASIC COPY → host file round-trips byte-exact, per-file 64-byte QDOS header convention honoured); `.mdv` microdrive detect + cart-name surfaced (full directory walk parked at OPEN-WORK §7 behind real-hardware oracle) |
-| Amstrad | Amstrad CPC 6128 | Floppy | AMSDOS, CP/M 2.2/Plus | **No** |
-| AmstradPCW | Amstrad PCW | Floppy | CP/M Plus | **No** |
-| TatungEinstein | Tatung Einstein | Floppy | Xtal/DOS (CP/M-compatible) | **No** |
-| SVI328 | Spectravideo SV-328 | Floppy | CP/M (MSX-DOS/FAT12 possible) | **No** |
-| Altair8800 | MITS Altair 8800 | Floppy, IDE/CF | CP/M | **No** |
-| MultiComp | Grant Searle MultiComp | Floppy | CP/M | **No** |
+| Amstrad | Amstrad CPC 6128 | Floppy | AMSDOS, CP/M 2.2/Plus | **Yes** — `fs::cpm` ships the `amstrad_data` + `amstrad_sys` DPBs covering both CPC data + system formats. |
+| AmstradPCW | Amstrad PCW | Floppy | CP/M Plus | **Yes** — `fs::cpm` `amstrad_pcw` DPB. |
+| TatungEinstein | Tatung Einstein | Floppy | Xtal/DOS (CP/M-compatible) | **Yes** — `fs::cpm` `einstein` DPB. |
+| SVI328 | Spectravideo SV-328 | Floppy | CP/M (MSX-DOS/FAT12 possible) | **Partial** — CP/M side covered by `svi328_cpm` DPB; the MSX-DOS / FAT12 floppy variant routes through the existing FAT driver but no SV-specific BPB quirks have been validated. |
+| Altair8800 | MITS Altair 8800 | Floppy, IDE/CF | CP/M | **Yes** — `fs::cpm` ships both `altair_8in` (8-inch floppy) and `altair_cf` (CompactFlash HDD) DPBs. |
+| MultiComp | Grant Searle MultiComp | Floppy | CP/M | **Yes** — `fs::cpm` `multicomp` DPB. |
 | C64 | Commodore 64/128 | Floppy | CBM DOS (flat track/sector) | **No** |
 | C128 | Commodore 128 | Floppy | CBM DOS | **No** |
 | C16 | Commodore C16/Plus4 | Floppy | CBM DOS | **No** |
@@ -74,7 +74,7 @@ Legend for the **Support** column:
 | PC88 | NEC PC-8801 mkII SR | Floppy | N88-BASIC Disk BASIC | **No** |
 | SAM-Coupe | SAM Coupe | Floppy | SAM DOS / MasterDOS | **No** |
 | ColecoAdam | Coleco Adam | Floppy, DDP tape | EOS (read-only in core) | **No** |
-| BK0011M | Elektronika BK | Floppy, HDD (VHD) | ANDOS / CSIDOS | **No** |
+| BK0011M | Elektronika BK | Floppy, HDD (VHD) | ANDOS / CSIDOS | **Partial** — `fs::andos` ships a detect-only scaffold (boot-block signature probe surfaces "ANDOS" through `fs_type()`). Browse / extract returns `Unsupported`; CSIDOS not started. Sparse public docs limit the work to what real-disc fixtures can validate. |
 | Vector-06C | Vector-06C | Floppy | MicroDOS | **No** |
 | Specialist | Specialist | Floppy | Specialist-MX FS | **No** |
 | ZX81 | Sinclair ZX80/ZX81 | Tape | — | **N/A** |

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -388,6 +388,12 @@ pub struct RustyBackupApp {
     bulk_convert_dialog: Option<BulkConvertDialog>,
     /// Background bulk-convert worker progress (None = idle).
     bulk_convert_status: Option<Arc<Mutex<BulkConvertStatus>>>,
+    /// File path passed on the command line (Windows file-association
+    /// double-click, macOS `open file.d88`, Linux `.desktop` MimeType
+    /// launch). Taken on the first `update()` tick, routed into the
+    /// Inspect tab, and the tab is switched to it. `None` for normal
+    /// launches without a file argv.
+    pending_initial_image: Option<PathBuf>,
 }
 
 impl Default for RustyBackupApp {
@@ -472,7 +478,54 @@ impl Default for RustyBackupApp {
             loaded_backup_folder: None,
             bulk_convert_dialog: None,
             bulk_convert_status: None,
+            pending_initial_image: None,
         }
+    }
+}
+
+impl RustyBackupApp {
+    /// Construct the app with an optional file path to auto-open on first
+    /// frame. Used by `main.rs` to wire up Windows file-association
+    /// double-clicks, macOS `open file.ext` launches, and Linux .desktop
+    /// MimeType handlers — all of them launch the binary with the file
+    /// path in argv.
+    pub fn with_initial_image(image: Option<PathBuf>) -> Self {
+        // Struct-update syntax keeps `field_reassign_with_default` happy:
+        // build everything through Default, then override the one field
+        // we care about. Default does the heavy device-enumeration + log
+        // priming so we don't want to duplicate it.
+        Self {
+            pending_initial_image: image,
+            ..Self::default()
+        }
+    }
+
+    /// Open a path in the Inspect tab and switch to it. Used by both the
+    /// command-line initial-image hand-off (one-shot at app start) and
+    /// the drag-and-drop handler (any time during the session).
+    ///
+    /// Routes through [`prepare_disk_image_path`] so wrapper formats with
+    /// no native seekable view (`.adz` / `.hdz` / `.msa` / `.d88` / `.xdf`
+    /// / `.hdm` / `.dim`) are decompressed to a flat tempfile first. Same
+    /// path the "Open File..." button uses — keeps DnD / double-click
+    /// behavior identical to the picker.
+    fn open_in_inspect(&mut self, path: PathBuf) {
+        self.log_panel.info(format!("Opening {}", path.display()));
+        match prepare_disk_image_path(&path) {
+            Ok((materialized, guard)) => {
+                self.inspect_tab
+                    .load_image_with_tempdir(materialized, guard);
+            }
+            Err(e) => {
+                self.log_panel.warn(format!(
+                    "Failed to materialize {}: {} — opening raw bytes",
+                    path.display(),
+                    e
+                ));
+                self.inspect_tab.load_image_with_tempdir(path, None);
+            }
+        }
+        self.active_tab = Tab::Inspect;
     }
 }
 
@@ -640,6 +693,25 @@ impl eframe::App for RustyBackupApp {
             || self.bulk_convert_status.is_some()
         {
             ctx.request_repaint();
+        }
+
+        // One-shot: drain the file path handed in on the command line
+        // (Windows file-association double-click, macOS `open ...`, Linux
+        // .desktop MimeType launch). Done in update() rather than the
+        // constructor because the inspect tab's lazy-load path needs the
+        // egui context to be alive.
+        if let Some(path) = self.pending_initial_image.take() {
+            self.open_in_inspect(path);
+        }
+
+        // Drag-and-drop: if the user dragged one or more files onto the
+        // app window, take the first one with a real filesystem path and
+        // open it in the Inspect tab. `with_drag_and_drop(true)` is set
+        // on the viewport in main.rs so eframe surfaces these events.
+        let dropped: Option<PathBuf> =
+            ctx.input(|i| i.raw.dropped_files.iter().find_map(|f| f.path.clone()));
+        if let Some(path) = dropped {
+            self.open_in_inspect(path);
         }
 
         // Drain `log` crate records (incl. worker-thread log::info! from the

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,35 @@
 
 mod gui;
 
+use std::path::PathBuf;
+
+/// Scan `std::env::args()` for the first non-flag positional that exists as
+/// a file on disk, and return it as a candidate to auto-open in the Inspect
+/// tab.
+///
+/// Triggered by:
+/// - Windows: file-association double-click in Explorer (the registered
+///   ProgID launches `rusty-backup.exe "C:\path\to\file.d88"`).
+/// - macOS: `open file.d88` from Finder runs
+///   `App.app/Contents/MacOS/rusty-backup <path>`.
+/// - Linux: `.desktop` MimeType handlers pass the file through `%F`/`%U`.
+///
+/// Skips:
+/// - argv[0] (the executable path itself).
+/// - Anything starting with `-` or `--` (flags, including the Windows
+///   association registrar's own `--register-file-associations` /
+///   `--unregister-file-associations`).
+/// - Strings that don't exist on disk as files (a stray non-flag token —
+///   e.g. an unexpected verb — shouldn't crash the GUI or silently produce
+///   a "file not found" error inside the Inspect tab).
+fn extract_initial_image_arg() -> Option<PathBuf> {
+    std::env::args()
+        .skip(1)
+        .filter(|a| !a.starts_with('-'))
+        .map(PathBuf::from)
+        .find(|p| p.is_file())
+}
+
 /// Windows: handle the installer/uninstaller association hooks
 /// (`--register-file-associations` / `--unregister-file-associations`) and the
 /// launch-time re-registration that picks up newly supported extensions after
@@ -160,13 +189,18 @@ fn main() -> eframe::Result {
         ..Default::default()
     };
 
+    // Pick up the file argv before the closure runs; the closure can fire
+    // multiple times under wgpu→glow fallback, and the arg should only be
+    // honored once (the first attempt).
+    let initial_image = extract_initial_image_arg();
     let run = |renderer: eframe::Renderer| {
+        let initial = initial_image.clone();
         eframe::run_native(
             "Rusty Backup",
             make_options(renderer),
-            Box::new(|cc| {
+            Box::new(move |cc| {
                 gui::ui_logger::set_repaint_ctx(cc.egui_ctx.clone());
-                Ok(Box::new(gui::RustyBackupApp::default()))
+                Ok(Box::new(gui::RustyBackupApp::with_initial_image(initial)))
             }),
         )
     };

--- a/src/model/file_types.rs
+++ b/src/model/file_types.rs
@@ -17,16 +17,10 @@
 /// uppercase variants of the case-sensitive container formats (rfd matches
 /// extensions case-sensitively on some platforms, so `.GHO` / `.HFV` need
 /// explicit entries to be selectable).
-///
-/// The Sharp / X68000 / PC-98 / FM-7 floppy-container family (`d88` / `xdf`
-/// / `hdm` / `dim`) is included with both cases — historical X68000 / PC-98
-/// archives ship a mix of `.D88` / `.XDF` (DOS-era uppercase legacy) and
-/// the modern lowercase emulator convention, so the picker needs both to
-/// match either.
 pub const DISK_IMAGE_EXTS: &[&str] = &[
     "vhd", "img", "raw", "bin", "iso", "dd", "hda", "hdv", "2mg", "dmg", "po", "do", "dsk", "dc42",
     "woz", "chd", "adf", "hdf", "adz", "hdz", "imz", "vmdk", "qcow2", "qcow", "gho", "ghs", "GHO",
-    "GHS", "hfv", "HFV", "d88", "D88", "xdf", "XDF", "hdm", "HDM", "dim", "DIM",
+    "GHS", "hfv", "HFV", "d88", "xdf", "hdm", "dim",
 ];
 
 /// Optical disc-image extensions (CD/DVD images), a distinct picker group.

--- a/src/model/file_types.rs
+++ b/src/model/file_types.rs
@@ -17,10 +17,16 @@
 /// uppercase variants of the case-sensitive container formats (rfd matches
 /// extensions case-sensitively on some platforms, so `.GHO` / `.HFV` need
 /// explicit entries to be selectable).
+///
+/// The Sharp / X68000 / PC-98 / FM-7 floppy-container family (`d88` / `xdf`
+/// / `hdm` / `dim`) is included with both cases — historical X68000 / PC-98
+/// archives ship a mix of `.D88` / `.XDF` (DOS-era uppercase legacy) and
+/// the modern lowercase emulator convention, so the picker needs both to
+/// match either.
 pub const DISK_IMAGE_EXTS: &[&str] = &[
     "vhd", "img", "raw", "bin", "iso", "dd", "hda", "hdv", "2mg", "dmg", "po", "do", "dsk", "dc42",
     "woz", "chd", "adf", "hdf", "adz", "hdz", "imz", "vmdk", "qcow2", "qcow", "gho", "ghs", "GHO",
-    "GHS", "hfv", "HFV",
+    "GHS", "hfv", "HFV", "d88", "D88", "xdf", "XDF", "hdm", "HDM", "dim", "DIM",
 ];
 
 /// Optical disc-image extensions (CD/DVD images), a distinct picker group.
@@ -76,6 +82,21 @@ mod tests {
             assert!(
                 association_exts().contains(&must.to_string()),
                 "missing {must}"
+            );
+        }
+    }
+
+    #[test]
+    fn floppy_container_family_present() {
+        // X68000 / PC-98 / FM-7 floppy containers — engine support
+        // (`rbformats::containers::{d88,xdf,hdm,dim}`) and the GUI
+        // `Convert Floppy Container...` dialog all assume the pickers
+        // surface these. Regression-pin them here so a future cleanup
+        // pass that prunes the disk-image list has to do it deliberately.
+        for must in ["d88", "xdf", "hdm", "dim"] {
+            assert!(
+                association_exts().contains(&must.to_string()),
+                "missing floppy-container extension {must}"
             );
         }
     }


### PR DESCRIPTION
- updated README.md
- updated mister formats
- added drag to inspect window to open files (if nothing is already open, otherwise you will inject files into the image)
- fixing windows file associations by parsing the filename to automatically open under inspect