### PR TITLE
macarchive: add Compact Pro (.cpt) read support + fix raw-extract for…

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -18,7 +18,6 @@ Usage: rb-cli [OPTIONS] <COMMAND>
 - `--color` — ANSI color usage. Honors the `NO_COLOR` env var when set. Built-in default `auto`
 - `--log-file` — Mirror full trace-level log output to PATH regardless of `--log-level`. Useful on Windows cmd where redirection is awkward
 - `--config` — Path to a config file. Overrides the platform default location. See `rb-cli config path` for what that location is
-- `-V` / `--version` — Print the `rb-cli` version and exit. Matches the version the GUI reports
 
 ## Verbs
 
@@ -405,7 +404,7 @@ Usage: convert [OPTIONS] <IN> <OUT>
 
 ### `expand`
 
-Expand a classic-HFS volume to a new size + allocation block size by cloning into a fresh APM disk image (default) or a bare HFS image (`--to-hfv`). Accepts APM-wrapped sources or raw single-partition HFS images.
+Expand a classic-HFS volume to a new size + allocation block size by cloning into a fresh APM disk image (default) or a bare HFS image (`--to-hfv`). Accepts APM-wrapped sources or raw single- partition HFS images
 
 ```
 Usage: expand [OPTIONS] --size <SIZE> --output <OUTPUT> <IMAGE>
@@ -421,6 +420,44 @@ Usage: expand [OPTIONS] --size <SIZE> --output <OUTPUT> <IMAGE>
 - `--block-size` — Allocation block size in bytes. One of: 4096, 8192, 16384, 32768, 65536. If omitted, picks the smallest block size whose 65535-block ceiling can hold `--size`
 - `--output` — Destination path for the new image. Created (or truncated)
 - `--to-hfv` — Write a flat BasiliskII HFV (bare classic-HFS volume, no partition table) instead of an APM disk image. Capped at 2047 MB. Use this to produce a `.hfv` for BasiliskII / SheepShaver
+
+### `floppy`
+
+Floppy-container verbs (convert / info) for XDF, HDM, DIM, D88
+
+```
+Usage: floppy <COMMAND>
+```
+
+### `floppy convert`
+
+Convert a floppy image between XDF / HDM / DIM / D88 formats. The output format is inferred from the destination extension
+
+```
+Usage: convert [OPTIONS] <INPUT> <OUTPUT>
+```
+
+**Arguments**
+
+- `<INPUT>` — Source floppy image (.xdf, .hdm, .dim, .d88) — or a directory of floppy images when paired with `--to`
+- `<OUTPUT>` — Destination path. For a file input the target format is taken from the extension; for a directory input pass a directory here and use `--to <fmt>` to pick the output format
+
+**Options**
+
+- `--to` — Output format for directory (bulk) mode. Required when `input` is a directory; ignored for single-file mode (extension wins there)
+- `--recursive` — Walk the input directory recursively. Only meaningful in bulk mode
+
+### `floppy info`
+
+Print the detected container kind and geometry for a floppy image
+
+```
+Usage: info <INPUT>
+```
+
+**Arguments**
+
+- `<INPUT>` — Floppy image to inspect
 
 ### `fsck`
 
@@ -464,6 +501,7 @@ Usage: get [OPTIONS] <IMAGE> <SRC> <DST>
 - `--force` — Overwrite existing host files. Mutually exclusive with `--skip-existing`
 - `--skip-existing` — Skip silently when a host file already exists. Mutually exclusive with `--force`. Without either flag, an existing destination is a hard error
 - `--password` — Password for encrypted containers (currently: WinImage IMZ)
+- `--fs-type` — Force a specific filesystem dispatch. The main use is `cpm:<preset>` for CP/M images (which have no on-disk signature). Valid CP/M presets: `amstrad_data`, `amstrad_sys`, `amstrad_pcw`, `einstein`, `svi328_cpm`, `altair_8in`, `altair_cf`, `multicomp`, `zx_plus3`. Other strings (e.g. `human68k`, `qdos`) are also accepted and forwarded to the partition_type_string dispatch
 
 ### `get-binhex`
 
@@ -567,6 +605,7 @@ Usage: ls [OPTIONS] <IMAGE> [PATH]
 - `--ignore-case` — Treat case-insensitively, regardless of the target's native rule
 - `--case-sensitive` — Treat case-sensitively, regardless of the target's native rule
 - `--password` — Password for encrypted containers (currently: WinImage IMZ)
+- `--fs-type` — Force a specific filesystem dispatch. The main use is `cpm:<preset>` for CP/M images (which have no on-disk signature). Valid CP/M presets: `amstrad_data`, `amstrad_sys`, `amstrad_pcw`, `einstein`, `svi328_cpm`, `altair_8in`, `altair_cf`, `multicomp`, `zx_plus3`. Other strings (e.g. `human68k`, `qdos`) are also accepted and forwarded to the partition_type_string dispatch
 
 ### `mkdir`
 
@@ -822,6 +861,7 @@ Usage: put [OPTIONS] <IMAGE> [HOST_FILE] [DST]
 - `--creator` — 4-character creator code (HFS / HFS+ only). Defaults to `????`, or `[put] creator` from the config file when set
 - `--force` — Overwrite an existing entry at the destination path
 - `--print-offset` — After writing the file, also print the same JSON envelope `locate` would have produced — absolute byte offset, length, fragmented flag. One-shot for build scripts that need to patch disk offsets immediately after placing a payload. HFS-only, matches the locate verb's scope; ignored (with a warning) for the `--zero` and `--boot` shapes since there's no host file to describe
+- `--fs-type` — Force a specific filesystem dispatch. The main use is `cpm:<preset>` for CP/M images (which have no on-disk signature). Valid CP/M presets: `amstrad_data`, `amstrad_sys`, `amstrad_pcw`, `einstein`, `svi328_cpm`, `altair_8in`, `altair_cf`, `multicomp`, `zx_plus3`. Other strings (e.g. `human68k`, `qdos`) are also accepted and forwarded to the partition_type_string dispatch
 
 ### `put-binhex`
 
@@ -883,7 +923,7 @@ Usage: reformat [OPTIONS] --fs <FS> <IMAGE>
 
 ### `repack`
 
-Defragment a Human68k (X68000) partition in place: clone it into a fresh, contiguously-packed volume and write that back. Reclaims holes the in-place `resize` can't (it keeps cluster byte-offsets, so it only trims trailing free space). Human68k FAT16 volumes only; the partition table is left untouched.
+Defragment a Human68k (X68000) partition in place: clone it into a fresh, contiguously-packed volume and write that back. Reclaims holes the in-place resizer can't (it keeps cluster byte-offsets)
 
 ```
 Usage: repack [OPTIONS] <IMAGE>
@@ -895,7 +935,7 @@ Usage: repack [OPTIONS] <IMAGE>
 
 **Options**
 
-- `--size` — New filesystem size in bytes (default: the partition's current filesystem size). Accepts suffixes (`K`, `M`, `G`). Must not exceed the partition capacity
+- `--size` — New filesystem size in bytes (default: the partition's current size). Accepts suffixes (`K`, `M`, `G`). Must not exceed the partition capacity
 
 ### `resize`
 
@@ -955,6 +995,7 @@ Usage: rm [OPTIONS] <IMAGE> <PATH>
 - `--exclude` — Exclude paths matching this glob from deletion. Repeatable. Exclude always wins over the positional pattern
 - `--ignore-case` — Match case-insensitively regardless of the target's native rule
 - `--case-sensitive` — Match case-sensitively regardless of the target's native rule
+- `--fs-type` — Force a specific filesystem dispatch. The main use is `cpm:<preset>` for CP/M images (which have no on-disk signature). Valid CP/M presets: `amstrad_data`, `amstrad_sys`, `amstrad_pcw`, `einstein`, `svi328_cpm`, `altair_8in`, `altair_cf`, `multicomp`, `zx_plus3`. Other strings (e.g. `human68k`, `qdos`) are also accepted and forwarded to the partition_type_string dispatch
 
 ### `setrsrc`
 
@@ -1070,7 +1111,7 @@ Usage: shrink <INPUT> <OUTPUT>
 
 ### `sit`
 
-Read classic StuffIt archives (list / extract; accepts .sit, .sea, and BinHex-wrapped .sit.hqx)
+Read classic StuffIt and Compact Pro archives (list / extract; accepts .sit, .sea, .cpt, and their BinHex-wrapped .hqx forms)
 
 ```
 Usage: sit <COMMAND>
@@ -1103,7 +1144,7 @@ Usage: extract [OPTIONS] <ARCHIVE> <DEST>
 
 **Arguments**
 
-- `<ARCHIVE>` — StuffIt archive (`.sit`, `.sea`, or `.sit.hqx`)
+- `<ARCHIVE>` — StuffIt or Compact Pro archive (`.sit`, `.sea`, `.cpt`, or `.hqx`)
 - `<DEST>` — Destination directory on the host (created if missing)
 
 **Options**
@@ -1120,7 +1161,7 @@ Usage: list <ARCHIVE>
 
 **Arguments**
 
-- `<ARCHIVE>` — StuffIt archive (`.sit`, `.sea`, or `.sit.hqx`)
+- `<ARCHIVE>` — StuffIt or Compact Pro archive (`.sit`, `.sea`, `.cpt`, or `.hqx`)
 
 ### `terminal`
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -194,8 +194,8 @@ pub enum Command {
         cmd: verbs::partmap::PartmapCommand,
     },
 
-    /// Read classic StuffIt archives (list / extract; accepts .sit, .sea,
-    /// and BinHex-wrapped .sit.hqx).
+    /// Read classic StuffIt and Compact Pro archives (list / extract; accepts
+    /// .sit, .sea, .cpt, and their BinHex-wrapped .hqx forms).
     Sit {
         #[command(subcommand)]
         cmd: verbs::sit::SitCommand,

--- a/src/cli/verbs/sit.rs
+++ b/src/cli/verbs/sit.rs
@@ -1,13 +1,13 @@
-//! `rb-cli sit <SUBCOMMAND>` — read classic StuffIt archives.
+//! `rb-cli sit <SUBCOMMAND>` — read classic StuffIt and Compact Pro archives.
 //!
 //! `sit list ARCHIVE` prints the entries; `sit extract ARCHIVE DEST` unpacks
 //! them to the host, preserving both forks and Finder info via a chosen
 //! container format (BinHex by default).
 //!
-//! ARCHIVE may be a raw `.sit`, a self-extracting `.sea`, or a BinHex-wrapped
-//! `.sit.hqx` — the latter is decoded transparently. Only the classic StuffIt
-//! format (`SIT!`) is supported; the newer StuffIt 5 (`.sitx`-era) format is a
-//! separate container and is rejected with a clear message.
+//! ARCHIVE may be a raw `.sit` / `.cpt`, a self-extracting `.sea`, or any of
+//! these BinHex-wrapped as `.hqx` — the wrapper is decoded transparently, and
+//! the format (classic StuffIt, StuffIt 5, or Compact Pro) is detected from
+//! content. StuffIt X (`.sitx`) is recognized but not yet extractable.
 
 use anyhow::{bail, Context, Result};
 use clap::{Args, Subcommand, ValueEnum};
@@ -47,13 +47,13 @@ pub struct CreateArgs {
 
 #[derive(Debug, Args)]
 pub struct ListArgs {
-    /// StuffIt archive (`.sit`, `.sea`, or `.sit.hqx`).
+    /// StuffIt or Compact Pro archive (`.sit`, `.sea`, `.cpt`, or `.hqx`).
     pub archive: PathBuf,
 }
 
 #[derive(Debug, Args)]
 pub struct ExtractArgs {
-    /// StuffIt archive (`.sit`, `.sea`, or `.sit.hqx`).
+    /// StuffIt or Compact Pro archive (`.sit`, `.sea`, `.cpt`, or `.hqx`).
     pub archive: PathBuf,
 
     /// Destination directory on the host (created if missing).

--- a/src/gui/browse_view.rs
+++ b/src/gui/browse_view.rs
@@ -3607,10 +3607,13 @@ impl BrowseView {
 
         let title = match pending.kind {
             MacArchiveKind::BinHexSingleFile => "Convert HQX file?",
-            MacArchiveKind::Sit | MacArchiveKind::Sit5 | MacArchiveKind::Sea => "Expand archive?",
-            MacArchiveKind::BinHexOverSit | MacArchiveKind::BinHexOverSea => {
-                "Convert and/or expand?"
-            }
+            MacArchiveKind::Sit
+            | MacArchiveKind::Sit5
+            | MacArchiveKind::Sea
+            | MacArchiveKind::CompactPro => "Expand archive?",
+            MacArchiveKind::BinHexOverSit
+            | MacArchiveKind::BinHexOverSea
+            | MacArchiveKind::BinHexOverCompactPro => "Convert and/or expand?",
         };
 
         egui::Window::new(title)
@@ -3625,10 +3628,15 @@ impl BrowseView {
                     MacArchiveKind::BinHexSingleFile => {
                         format!("Would you like to convert {filename} to binary?")
                     }
-                    MacArchiveKind::Sit | MacArchiveKind::Sit5 | MacArchiveKind::Sea => {
+                    MacArchiveKind::Sit
+                    | MacArchiveKind::Sit5
+                    | MacArchiveKind::Sea
+                    | MacArchiveKind::CompactPro => {
                         format!("Would you like to expand the contents of {filename}?")
                     }
-                    MacArchiveKind::BinHexOverSit | MacArchiveKind::BinHexOverSea => {
+                    MacArchiveKind::BinHexOverSit
+                    | MacArchiveKind::BinHexOverSea
+                    | MacArchiveKind::BinHexOverCompactPro => {
                         format!(
                             "Would you like to convert {filename} to binary and/or expand the contents?"
                         )
@@ -3659,7 +3667,10 @@ impl BrowseView {
                             action = Some(ImportAction::Cancel);
                         }
                     }
-                    MacArchiveKind::Sit | MacArchiveKind::Sit5 | MacArchiveKind::Sea => {
+                    MacArchiveKind::Sit
+                    | MacArchiveKind::Sit5
+                    | MacArchiveKind::Sea
+                    | MacArchiveKind::CompactPro => {
                         if ui
                             .button("Expand")
                             .on_hover_text(
@@ -3681,7 +3692,9 @@ impl BrowseView {
                             action = Some(ImportAction::Cancel);
                         }
                     }
-                    MacArchiveKind::BinHexOverSit | MacArchiveKind::BinHexOverSea => {
+                    MacArchiveKind::BinHexOverSit
+                    | MacArchiveKind::BinHexOverSea
+                    | MacArchiveKind::BinHexOverCompactPro => {
                         if ui
                             .button("Convert and expand")
                             .on_hover_text(
@@ -3694,6 +3707,9 @@ impl BrowseView {
                         }
                         let convert_only_label = match pending.kind {
                             MacArchiveKind::BinHexOverSea => "Convert only (.sea lands here)",
+                            MacArchiveKind::BinHexOverCompactPro => {
+                                "Convert only (inner archive lands here)"
+                            }
                             _ => "Convert only (.sit lands here)",
                         };
                         if ui

--- a/src/macarchive/compactpro.rs
+++ b/src/macarchive/compactpro.rs
@@ -1,0 +1,928 @@
+//! Compact Pro (`.cpt`) archive reader — Bill Goodman's Compactor / Compact
+//! Pro format, common for vintage Mac software and frequently distributed as a
+//! BinHex-wrapped self-extracting archive (`.sea.hqx`).
+//!
+//! Two-stage compression: a byte-level RLE layer, optionally fed by an LZH
+//! (LZSS + canonical Huffman) layer. Each file carries a data and/or resource
+//! fork plus Finder info, mapping cleanly onto the shared [`StuffItEntry`] /
+//! [`StuffItArchive`] plumbing the rest of `macarchive` already uses, so the
+//! directory tree and all four output formats in `extract` come for free.
+//!
+//! Ported from XADMaster's `XADCompactProParser.m`,
+//! `XADCompactProRLEHandle.m`, and `XADCompactProLZHHandle.m` (which build on
+//! `XADLZSSHandle`, `XADPrefixCode`, and `CSInputBuffer`, all under
+//! `~/repos/XADMaster`). The block-padding quirk in the LZH layer and the
+//! RLE escape sequence are faithful reproductions of that reference.
+
+use anyhow::{bail, Result};
+use byteorder::{BigEndian, ByteOrder};
+use std::sync::OnceLock;
+
+use super::stuffit::{ForkCodec, ForkInfo, StuffItArchive, StuffItEntry};
+use crate::fs::hfs::mac_roman_to_utf8;
+
+/// Bytes of file metadata that follow a file entry's name (volume, offset,
+/// type/creator, two dates, finder flags, crc, flags, four lengths).
+const FILE_METADATA_LEN: usize = 45;
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+/// True iff `bytes` is a Compact Pro archive. Mirrors XADMaster's recognizer:
+/// the leading `0x01` marker is far too weak on its own, so we walk the index
+/// at the end of the file and confirm the stored CRC-32 over the directory.
+pub fn is_compactpro(bytes: &[u8]) -> bool {
+    validate_index(bytes).unwrap_or(false)
+}
+
+/// Walk the index and check its CRC; `Some(true)` only when everything lines
+/// up. Returns `Ok(false)` / `None`-equivalent for any structural problem so
+/// the detector never panics on hostile input.
+fn validate_index(bytes: &[u8]) -> Option<bool> {
+    if bytes.len() < 8 || bytes[0] != 1 {
+        return Some(false);
+    }
+    let offset = BigEndian::read_u32(bytes.get(4..8)?) as usize;
+    // headcrc(4) + numentries(2) + commentlen(1)
+    let correct = BigEndian::read_u32(bytes.get(offset..offset + 4)?);
+    let mut p = offset + 4;
+
+    let head = bytes.get(p..p + 3)?;
+    let mut crc = crc32_update(0xffff_ffff, head);
+    let numentries = BigEndian::read_u16(&head[0..2]) as usize;
+    let commentsize = head[2] as usize;
+    p += 3;
+
+    let comment = bytes.get(p..p + commentsize)?;
+    crc = crc32_update(crc, comment);
+    p += commentsize;
+
+    for _ in 0..numentries {
+        let namelen = *bytes.get(p)?;
+        crc = crc32_update(crc, &[namelen]);
+        p += 1;
+        let nl = (namelen & 0x7f) as usize;
+        let namebytes = bytes.get(p..p + nl)?;
+        crc = crc32_update(crc, namebytes);
+        p += nl;
+        let metadatasize = if namelen & 0x80 != 0 {
+            2
+        } else {
+            FILE_METADATA_LEN
+        };
+        let meta = bytes.get(p..p + metadatasize)?;
+        crc = crc32_update(crc, meta);
+        p += metadatasize;
+    }
+
+    Some(crc == correct)
+}
+
+// ---------------------------------------------------------------------------
+// Directory parsing
+// ---------------------------------------------------------------------------
+
+/// Parse a Compact Pro archive's directory into the shared entry tree. Fork
+/// data offsets are absolute within `bytes`, exactly like the StuffIt parsers.
+pub fn parse(bytes: &[u8]) -> Result<StuffItArchive> {
+    if bytes.len() < 8 || bytes[0] != 1 {
+        bail!("not a Compact Pro archive");
+    }
+    let index_offset = BigEndian::read_u32(&bytes[4..8]) as usize;
+    let mut pos = index_offset;
+
+    // headcrc(4) numentries(2) commentlen(1)
+    if pos + 7 > bytes.len() {
+        bail!("Compact Pro: truncated archive index");
+    }
+    pos += 4; // skip stored header CRC (validated in is_compactpro)
+    let numentries = BigEndian::read_u16(&bytes[pos..pos + 2]) as usize;
+    pos += 2;
+    let commentlen = bytes[pos] as usize;
+    pos += 1;
+    pos = pos
+        .checked_add(commentlen)
+        .filter(|&p| p <= bytes.len())
+        .ok_or_else(|| anyhow::anyhow!("Compact Pro: comment runs past end of archive"))?;
+
+    let mut entries = Vec::new();
+    parse_directory(bytes, &mut pos, &[], numentries, &mut entries)?;
+    Ok(StuffItArchive { entries })
+}
+
+fn parse_directory(
+    bytes: &[u8],
+    pos: &mut usize,
+    parent: &[String],
+    mut numentries: usize,
+    entries: &mut Vec<StuffItEntry>,
+) -> Result<()> {
+    while numentries > 0 {
+        let namelen = *bytes
+            .get(*pos)
+            .ok_or_else(|| anyhow::anyhow!("Compact Pro: index truncated mid-entry"))?;
+        *pos += 1;
+        let nl = (namelen & 0x7f) as usize;
+        let namebytes = bytes
+            .get(*pos..*pos + nl)
+            .ok_or_else(|| anyhow::anyhow!("Compact Pro: name runs past end of archive"))?;
+        let name = mac_roman_to_utf8(namebytes);
+        *pos += nl;
+
+        let mut path = parent.to_vec();
+        path.push(name.clone());
+
+        if namelen & 0x80 != 0 {
+            // Directory: 2-byte (recursive) descendant count.
+            let numdir = read_u16(bytes, pos)? as usize;
+            entries.push(StuffItEntry {
+                path: path.clone(),
+                name,
+                is_dir: true,
+                type_code: [0; 4],
+                creator_code: [0; 4],
+                finder_flags: 0,
+                create_date: 0,
+                mod_date: 0,
+                data: None,
+                rsrc: None,
+            });
+            parse_directory(bytes, pos, &path, numdir, entries)?;
+            numentries = numentries
+                .checked_sub(numdir + 1)
+                .ok_or_else(|| anyhow::anyhow!("Compact Pro: inconsistent directory count"))?;
+        } else {
+            // File: 45 bytes of metadata.
+            let meta = bytes
+                .get(*pos..*pos + FILE_METADATA_LEN)
+                .ok_or_else(|| anyhow::anyhow!("Compact Pro: file metadata past end of archive"))?;
+            *pos += FILE_METADATA_LEN;
+
+            // volume@0, fileoffs@1, type@5, creator@9, cdate@13, mdate@17,
+            // finderflags@21, crc@23, flags@27, rsrclen@29, datalen@33,
+            // rsrccomplen@37, datacomplen@41.
+            let fileoffs = BigEndian::read_u32(&meta[1..5]) as u64;
+            let mut type_code = [0u8; 4];
+            type_code.copy_from_slice(&meta[5..9]);
+            let mut creator_code = [0u8; 4];
+            creator_code.copy_from_slice(&meta[9..13]);
+            let create_date = BigEndian::read_u32(&meta[13..17]);
+            let mod_date = BigEndian::read_u32(&meta[17..21]);
+            let finder_flags = BigEndian::read_u16(&meta[21..23]);
+            let crc = BigEndian::read_u32(&meta[23..27]);
+            let flags = BigEndian::read_u16(&meta[27..29]);
+            let resourcelength = BigEndian::read_u32(&meta[29..33]);
+            let datalength = BigEndian::read_u32(&meta[33..37]);
+            let resourcecomplen = BigEndian::read_u32(&meta[37..41]);
+            let datacomplen = BigEndian::read_u32(&meta[41..45]);
+
+            let encrypted = flags & 1 != 0;
+
+            // Resource fork present when it has uncompressed bytes; its LZH bit
+            // is flags&2. The single per-file CRC-32 is carried on both forks
+            // and verified once per entry (see [`verify_entry_crc`]).
+            let rsrc = if resourcelength > 0 {
+                Some(ForkInfo {
+                    method: 0,
+                    codec: ForkCodec::CompactPro {
+                        lzh: flags & 2 != 0,
+                    },
+                    encrypted,
+                    uncompressed_len: resourcelength,
+                    compressed_len: resourcecomplen,
+                    crc: 0,
+                    crc32: crc,
+                    offset: fileoffs,
+                })
+            } else {
+                None
+            };
+            // Data fork present when it has bytes, or when the file has neither
+            // fork (a zero-length data fork). Its LZH bit is flags&4.
+            let data = if datalength > 0 || resourcelength == 0 {
+                Some(ForkInfo {
+                    method: 0,
+                    codec: ForkCodec::CompactPro {
+                        lzh: flags & 4 != 0,
+                    },
+                    encrypted,
+                    uncompressed_len: datalength,
+                    compressed_len: datacomplen,
+                    crc: 0,
+                    crc32: crc,
+                    offset: fileoffs + resourcecomplen as u64,
+                })
+            } else {
+                None
+            };
+
+            entries.push(StuffItEntry {
+                path,
+                name,
+                is_dir: false,
+                type_code,
+                creator_code,
+                finder_flags,
+                create_date,
+                mod_date,
+                data,
+                rsrc,
+            });
+            numentries -= 1;
+        }
+    }
+    Ok(())
+}
+
+fn read_u16(bytes: &[u8], pos: &mut usize) -> Result<u16> {
+    let v = bytes
+        .get(*pos..*pos + 2)
+        .ok_or_else(|| anyhow::anyhow!("Compact Pro: index truncated"))?;
+    *pos += 2;
+    Ok(BigEndian::read_u16(v))
+}
+
+// ---------------------------------------------------------------------------
+// Fork decompression
+// ---------------------------------------------------------------------------
+
+/// Decompress one Compact Pro fork (RLE, optionally LZH-fed). The CRC is not
+/// checked here — Compact Pro stores one checksum per *file* covering the
+/// resource fork followed by the data fork, so the caller verifies it once
+/// both forks are in hand via [`verify_entry_crc`].
+pub fn decompress_fork(archive: &[u8], fork: &ForkInfo) -> Result<Vec<u8>> {
+    let lzh = match fork.codec {
+        ForkCodec::CompactPro { lzh } => lzh,
+        ForkCodec::StuffIt => bail!("compactpro::decompress_fork called on a StuffIt fork"),
+    };
+    if fork.encrypted {
+        bail!("Compact Pro: encrypted entries are not supported");
+    }
+
+    let start = fork.offset as usize;
+    let end = start
+        .checked_add(fork.compressed_len as usize)
+        .ok_or_else(|| anyhow::anyhow!("Compact Pro: fork length overflow"))?;
+    if end > archive.len() {
+        bail!("Compact Pro: fork data extends past end of archive");
+    }
+    let comp = &archive[start..end];
+    let out_len = fork.uncompressed_len as usize;
+
+    if lzh {
+        let mut src = CpLzh::new(comp);
+        rle_decode(&mut src, out_len)
+    } else {
+        let mut src = SliceSource::new(comp);
+        rle_decode(&mut src, out_len)
+    }
+}
+
+/// Verify a Compact Pro file's CRC-32. The stored checksum covers the
+/// decompressed resource fork immediately followed by the decompressed data
+/// fork (either may be empty), as a single reflected CRC-32 with no final
+/// complement. This is the only integrity check for the format, so it runs
+/// for every entry — single-fork, dual-fork, and empty alike.
+pub fn verify_entry_crc(rsrc: &[u8], data: &[u8], expected: u32) -> Result<()> {
+    let got = crc32_update(crc32_update(0xffff_ffff, rsrc), data);
+    if got != expected {
+        bail!("Compact Pro: file CRC mismatch (got {got:#010x}, expected {expected:#010x})");
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// RLE layer (XADCompactProRLEHandle)
+// ---------------------------------------------------------------------------
+
+/// A byte source the RLE layer pulls from: either the LZH decoder or, for
+/// RLE-only forks, the raw compressed bytes.
+trait ByteSource {
+    fn next_byte(&mut self) -> Option<u8>;
+}
+
+struct SliceSource<'a> {
+    data: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> SliceSource<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        SliceSource { data, pos: 0 }
+    }
+}
+
+impl ByteSource for SliceSource<'_> {
+    fn next_byte(&mut self) -> Option<u8> {
+        let v = self.data.get(self.pos).copied();
+        if v.is_some() {
+            self.pos += 1;
+        }
+        v
+    }
+}
+
+#[derive(Default)]
+struct RleState {
+    saved: u8,
+    /// Remaining repeats of `saved`. Signed so a malformed short run count
+    /// can't wrap into a huge positive value (matches XAD's `int repeat`).
+    repeat: i64,
+    halfescaped: bool,
+}
+
+/// Produce one decompressed byte, mirroring `produceByteAtOffset`. `0x81` is
+/// the escape; `0x81 0x82 n` repeats the previous byte, `0x81 0x82 0` emits a
+/// literal `0x81 0x82`, `0x81 0x81` emits a literal `0x81`, and `0x81 x`
+/// emits `0x81 x`.
+fn rle_next(st: &mut RleState, src: &mut dyn ByteSource) -> Option<u8> {
+    if st.repeat != 0 {
+        st.repeat -= 1;
+        return Some(st.saved);
+    }
+
+    let byte = if st.halfescaped {
+        st.halfescaped = false;
+        0x81
+    } else {
+        src.next_byte()?
+    };
+
+    if byte != 0x81 {
+        st.saved = byte;
+        return Some(byte);
+    }
+
+    let b2 = src.next_byte()?;
+    if b2 == 0x82 {
+        let count = src.next_byte()?;
+        if count != 0 {
+            st.repeat = count as i64 - 2;
+            Some(st.saved)
+        } else {
+            st.repeat = 1;
+            st.saved = 0x82;
+            Some(0x81)
+        }
+    } else if b2 == 0x81 {
+        st.halfescaped = true;
+        st.saved = 0x81;
+        Some(0x81)
+    } else {
+        st.repeat = 1;
+        st.saved = b2;
+        Some(0x81)
+    }
+}
+
+fn rle_decode(src: &mut dyn ByteSource, out_len: usize) -> Result<Vec<u8>> {
+    let mut out = Vec::with_capacity(out_len);
+    let mut st = RleState::default();
+    while out.len() < out_len {
+        match rle_next(&mut st, src) {
+            Some(b) => out.push(b),
+            None => bail!(
+                "Compact Pro: unexpected end of compressed data ({} of {} bytes)",
+                out.len(),
+                out_len
+            ),
+        }
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// LZH layer (XADCompactProLZHHandle over XADLZSSHandle)
+// ---------------------------------------------------------------------------
+
+const LZH_BLOCKSIZE: i64 = 0x1fff0;
+const LZH_WINDOW_MASK: u64 = 0x1fff; // 8192-byte window
+
+enum Token {
+    Literal(u8),
+    Match { offset: u32, length: i32 },
+}
+
+struct CpLzh<'a> {
+    input: CpInput<'a>,
+    window: Vec<u8>,
+    pos: u64,
+    matchlength: i32,
+    matchoffset: u64,
+    blockcount: i64,
+    blockstart: i64,
+    literalcode: Option<Huff>,
+    lengthcode: Option<Huff>,
+    offsetcode: Option<Huff>,
+    ended: bool,
+}
+
+impl<'a> CpLzh<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        CpLzh {
+            input: CpInput::new(data),
+            window: vec![0u8; (LZH_WINDOW_MASK + 1) as usize],
+            pos: 0,
+            matchlength: 0,
+            matchoffset: 0,
+            blockcount: LZH_BLOCKSIZE, // force a block header on first token
+            blockstart: 0,
+            literalcode: None,
+            lengthcode: None,
+            offsetcode: None,
+            ended: false,
+        }
+    }
+
+    fn produce(&mut self) -> Option<u8> {
+        if self.ended {
+            return None;
+        }
+        if self.matchlength == 0 {
+            match self.next_token() {
+                Some(Token::Literal(v)) => {
+                    self.window[(self.pos & LZH_WINDOW_MASK) as usize] = v;
+                    self.pos = self.pos.wrapping_add(1);
+                    return Some(v);
+                }
+                Some(Token::Match { offset, length }) => {
+                    self.matchlength = length;
+                    self.matchoffset = self.pos.wrapping_sub(offset as u64);
+                    // fall through to copy the first matched byte
+                }
+                None => {
+                    self.ended = true;
+                    return None;
+                }
+            }
+        }
+
+        self.matchlength -= 1;
+        let byte = self.window[(self.matchoffset & LZH_WINDOW_MASK) as usize];
+        self.matchoffset = self.matchoffset.wrapping_add(1);
+        self.window[(self.pos & LZH_WINDOW_MASK) as usize] = byte;
+        self.pos = self.pos.wrapping_add(1);
+        Some(byte)
+    }
+
+    fn next_token(&mut self) -> Option<Token> {
+        if self.blockcount >= LZH_BLOCKSIZE {
+            if self.blockstart != 0 {
+                // Skip the inter-block padding. (XAD's verbatim comment: "Don't
+                // let your bad implementations leak into your file formats,
+                // people!") Pad to an even offset relative to the block start.
+                self.input.skip_to_byte_boundary();
+                if (self.input.buffer_offset() - self.blockstart) & 1 != 0 {
+                    self.input.skip_bytes(3);
+                } else {
+                    self.input.skip_bytes(2);
+                }
+            }
+            self.literalcode = Some(self.parse_code(256)?);
+            self.lengthcode = Some(self.parse_code(64)?);
+            self.offsetcode = Some(self.parse_code(128)?);
+            self.blockcount = 0;
+            self.blockstart = self.input.buffer_offset();
+        }
+
+        if self.input.next_bit() != 0 {
+            self.blockcount += 2;
+            let sym = Huff::decode(self.literalcode.as_ref()?, &mut self.input)?;
+            Some(Token::Literal(sym as u8))
+        } else {
+            self.blockcount += 3;
+            let length = Huff::decode(self.lengthcode.as_ref()?, &mut self.input)?;
+            let osym = Huff::decode(self.offsetcode.as_ref()?, &mut self.input)?;
+            let offset = ((osym as u32) << 6) | self.input.next_bits(6);
+            Some(Token::Match { offset, length })
+        }
+    }
+
+    /// Parse one Huffman sub-table: a byte count, then that many bytes of two
+    /// 4-bit code lengths each; the remaining symbols are absent (length 0).
+    fn parse_code(&mut self, size: usize) -> Option<Huff> {
+        let numbytes = self.input.next_byte()? as usize;
+        if numbytes * 2 > size {
+            return None;
+        }
+        let mut lengths = vec![0i32; size];
+        for i in 0..numbytes {
+            let val = self.input.next_byte()? as i32;
+            lengths[2 * i] = val >> 4;
+            lengths[2 * i + 1] = val & 0x0f;
+        }
+        Huff::build(&lengths)
+    }
+}
+
+impl ByteSource for CpLzh<'_> {
+    fn next_byte(&mut self) -> Option<u8> {
+        self.produce()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Canonical Huffman (XADPrefixCode, shortestCodeIsZeros, high-bit-first)
+// ---------------------------------------------------------------------------
+
+const HUFF_MAX_BITS: usize = 15;
+
+/// Canonical prefix code decoded high-bit-first, matching XADPrefixCode with
+/// `shortestCodeIsZeros:YES`. Built from per-symbol bit lengths (0 = absent).
+struct Huff {
+    /// `counts[len]` = number of symbols assigned a code of that length.
+    counts: [u16; HUFF_MAX_BITS + 1],
+    /// Symbols ordered by (length, symbol value) — the canonical order.
+    symbols: Vec<i32>,
+}
+
+impl Huff {
+    fn build(lengths: &[i32]) -> Option<Huff> {
+        let mut counts = [0u16; HUFF_MAX_BITS + 1];
+        for &l in lengths {
+            if !(0..=HUFF_MAX_BITS as i32).contains(&l) {
+                return None;
+            }
+            counts[l as usize] += 1;
+        }
+        // An all-absent table is valid but decodes nothing; reject over-
+        // subscribed code spaces (incomplete ones are allowed: a single symbol).
+        let mut left: i64 = 1;
+        for &count in &counts[1..=HUFF_MAX_BITS] {
+            left = (left << 1) - count as i64;
+            if left < 0 {
+                return None;
+            }
+        }
+
+        // Offsets into the symbol table, sorted by symbol within each length.
+        let mut offs = [0u16; HUFF_MAX_BITS + 2];
+        for len in 1..=HUFF_MAX_BITS {
+            offs[len + 1] = offs[len] + counts[len];
+        }
+        let total = offs[HUFF_MAX_BITS + 1] as usize;
+        let mut symbols = vec![0i32; total];
+        for (sym, &len) in lengths.iter().enumerate() {
+            if len != 0 {
+                symbols[offs[len as usize] as usize] = sym as i32;
+                offs[len as usize] += 1;
+            }
+        }
+
+        Some(Huff { counts, symbols })
+    }
+
+    /// Decode one symbol, consuming bits high-bit-first (puff.c's algorithm,
+    /// the inverse of the canonical assignment). Returns `None` on an invalid
+    /// or truncated code.
+    fn decode(&self, input: &mut CpInput) -> Option<i32> {
+        let mut code: i32 = 0;
+        let mut first: i32 = 0;
+        let mut index: i32 = 0;
+        for len in 1..=HUFF_MAX_BITS {
+            code |= input.next_bit() as i32;
+            let count = self.counts[len] as i32;
+            if code - count < first {
+                return self.symbols.get((index + (code - first)) as usize).copied();
+            }
+            index += count;
+            first += count;
+            first <<= 1;
+            code <<= 1;
+        }
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bit reader (CSInputBuffer, non-LE path) over an in-memory slice
+// ---------------------------------------------------------------------------
+
+/// MSB-first bit reader replicating XADMaster's `CSInputBuffer` byte/bit
+/// accounting closely enough that `buffer_offset()` (its `currbyte`) tracks
+/// `ceil(consumed_bits / 8)` — the LZH block-padding skip depends on it. Reads
+/// past end-of-input yield zero bits / `None` bytes rather than panicking.
+struct CpInput<'a> {
+    data: &'a [u8],
+    currbyte: usize,
+    bits: u32,
+    numbits: u32,
+}
+
+impl<'a> CpInput<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        CpInput {
+            data,
+            currbyte: 0,
+            bits: 0,
+            numbits: 0,
+        }
+    }
+
+    fn peek_byte(&self, offs: usize) -> u32 {
+        match self.data.get(self.currbyte + offs) {
+            Some(&b) => b as u32,
+            None => 0,
+        }
+    }
+
+    fn fill_bits(&mut self) {
+        let mut numbytes = ((32 - self.numbits) >> 3) as usize;
+        let left = self.data.len().saturating_sub(self.currbyte);
+        if numbytes > left {
+            numbytes = left;
+        }
+        let s = (self.numbits >> 3) as usize;
+        match numbytes {
+            4 => {
+                self.bits = (self.peek_byte(s) << 24)
+                    | (self.peek_byte(s + 1) << 16)
+                    | (self.peek_byte(s + 2) << 8)
+                    | self.peek_byte(s + 3);
+            }
+            3 => {
+                self.bits |= ((self.peek_byte(s) << 16)
+                    | (self.peek_byte(s + 1) << 8)
+                    | self.peek_byte(s + 2))
+                    << (8 - self.numbits);
+            }
+            2 => {
+                self.bits |=
+                    ((self.peek_byte(s) << 8) | self.peek_byte(s + 1)) << (16 - self.numbits);
+            }
+            1 => {
+                self.bits |= self.peek_byte(s) << (24 - self.numbits);
+            }
+            _ => {}
+        }
+        self.numbits += (numbytes as u32) * 8;
+    }
+
+    fn peek_bits(&mut self, n: u32) -> u32 {
+        if n == 0 {
+            return 0;
+        }
+        if n > self.numbits {
+            self.fill_bits();
+        }
+        self.bits >> (32 - n)
+    }
+
+    fn skip_peeked(&mut self, n: u32) {
+        let numbytes = ((n as i64) - ((self.numbits & 7) as i64) + 7) >> 3;
+        self.currbyte += numbytes.max(0) as usize;
+        self.bits = if n >= 32 { 0 } else { self.bits << n };
+        self.numbits = self.numbits.saturating_sub(n);
+    }
+
+    fn next_bit(&mut self) -> u32 {
+        let b = self.peek_bits(1);
+        self.skip_peeked(1);
+        b
+    }
+
+    fn next_bits(&mut self, n: u32) -> u32 {
+        if n == 0 {
+            return 0;
+        }
+        let b = self.peek_bits(n);
+        self.skip_peeked(n);
+        b
+    }
+
+    /// Byte-aligned read (Compact Pro only uses this at block boundaries, where
+    /// the stream is on a byte boundary). `None` past end of input.
+    fn next_byte(&mut self) -> Option<u8> {
+        let v = self.data.get(self.currbyte).copied();
+        if v.is_some() {
+            self.currbyte += 1;
+        }
+        v
+    }
+
+    fn skip_to_byte_boundary(&mut self) {
+        self.bits = 0;
+        self.numbits = 0;
+    }
+
+    fn skip_bytes(&mut self, n: usize) {
+        self.currbyte += n;
+    }
+
+    fn buffer_offset(&self) -> i64 {
+        self.currbyte as i64
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CRC-32 (reflected, polynomial 0xedb88320, no final XOR — Compact Pro stores
+// the running value directly)
+// ---------------------------------------------------------------------------
+
+fn crc_table() -> &'static [u32; 256] {
+    static TABLE: OnceLock<[u32; 256]> = OnceLock::new();
+    TABLE.get_or_init(|| {
+        let mut t = [0u32; 256];
+        let mut n = 0usize;
+        while n < 256 {
+            let mut c = n as u32;
+            let mut k = 0;
+            while k < 8 {
+                c = if c & 1 != 0 {
+                    0xedb8_8320 ^ (c >> 1)
+                } else {
+                    c >> 1
+                };
+                k += 1;
+            }
+            t[n] = c;
+            n += 1;
+        }
+        t
+    })
+}
+
+fn crc32_update(mut crc: u32, data: &[u8]) -> u32 {
+    let t = crc_table();
+    for &b in data {
+        crc = t[((crc ^ b as u32) & 0xff) as usize] ^ (crc >> 8);
+    }
+    crc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// RLE: a plain byte stream with no `0x81` escapes round-trips verbatim.
+    #[test]
+    fn rle_passthrough_without_escapes() {
+        let mut src = SliceSource::new(&[1, 2, 3, 4, 5]);
+        let out = rle_decode(&mut src, 5).unwrap();
+        assert_eq!(out, vec![1, 2, 3, 4, 5]);
+    }
+
+    /// RLE run: literal `A` then `0x81 0x82 0x04` repeats it to four total.
+    #[test]
+    fn rle_run_repeats_previous_byte() {
+        let mut src = SliceSource::new(&[b'A', 0x81, 0x82, 0x04]);
+        let out = rle_decode(&mut src, 4).unwrap();
+        assert_eq!(out, vec![b'A', b'A', b'A', b'A']);
+    }
+
+    /// RLE escape for a literal `0x81 0x82` pair: `0x81 0x82 0x00`.
+    #[test]
+    fn rle_literal_escape_pair() {
+        let mut src = SliceSource::new(&[0x81, 0x82, 0x00]);
+        let out = rle_decode(&mut src, 2).unwrap();
+        assert_eq!(out, vec![0x81, 0x82]);
+    }
+
+    /// CRC-32 stored form is the running value with no final complement; an
+    /// empty buffer leaves the seed untouched.
+    #[test]
+    fn crc32_empty_is_seed() {
+        assert_eq!(crc32_update(0xffff_ffff, &[]), 0xffff_ffff);
+    }
+
+    /// Reflected CRC-32 over "123456789": standard check value 0xCBF43926
+    /// after final XOR, i.e. the stored (pre-XOR) value is its complement.
+    #[test]
+    fn crc32_check_value() {
+        let stored = crc32_update(0xffff_ffff, b"123456789");
+        assert_eq!(stored ^ 0xffff_ffff, 0xCBF4_3926);
+    }
+
+    /// End-to-end against a real **multi-block** Compact Pro archive (the
+    /// 150 KB "Dunjin Text" data fork spans three LZH blocks, so this exercises
+    /// the inter-block padding skip). Freely available from the IF Archive at
+    /// `if-archive/games/mac/Dunjin44.cpt.hqx`. No-op when the file is absent.
+    /// Every entry's per-file CRC-32 is checked, which is the format's own
+    /// integrity guarantee — a decode error anywhere would fail it.
+    #[test]
+    fn extract_real_compactpro_if_present() {
+        let path = std::path::Path::new("/Users/dani/Downloads/Dunjin44.cpt.hqx");
+        if !path.is_file() {
+            return;
+        }
+        let raw = std::fs::read(path).unwrap();
+        let bh = crate::fs::binhex::parse_binhex(&raw).expect("binhex decode");
+        assert!(is_compactpro(&bh.data_fork), "should detect Compact Pro");
+        let archive = parse(&bh.data_fork).expect("compactpro parse");
+        let files: Vec<_> = archive.entries.iter().filter(|e| !e.is_dir).collect();
+        assert!(!files.is_empty());
+
+        let mut verified = 0;
+        let mut saw_multiblock_fork = false;
+        for e in &files {
+            let decode = |f: &ForkInfo| {
+                decompress_fork(&bh.data_fork, f).unwrap_or_else(|err| panic!("{}: {err}", e.name))
+            };
+            let data = e.data.as_ref().map(&decode).unwrap_or_default();
+            let rsrc = e.rsrc.as_ref().map(&decode).unwrap_or_default();
+            // > ~128 KB of fork data guarantees the LZH stream crossed a block.
+            if data.len() >= 150_000 || rsrc.len() >= 150_000 {
+                saw_multiblock_fork = true;
+            }
+            // The per-file CRC-32 rides on whichever fork(s) the file has.
+            if let Some(crc) = e.data.as_ref().or(e.rsrc.as_ref()).map(|f| f.crc32) {
+                verify_entry_crc(&rsrc, &data, crc)
+                    .unwrap_or_else(|err| panic!("{}: {err}", e.name));
+                verified += 1;
+            }
+        }
+        assert!(
+            saw_multiblock_fork,
+            "expected the 150 KB multi-block Dunjin Text fork"
+        );
+        assert!(verified > 0);
+        eprintln!("Compact Pro: CRC-verified {verified} entries (incl. multi-block)");
+    }
+
+    /// Bits are consumed MSB-first, matching XADMaster's `CSInputNextBit` /
+    /// `CSInputNextBitString`.
+    #[test]
+    fn cpinput_reads_bits_msb_first() {
+        let mut inp = CpInput::new(&[0b1011_0010]);
+        let bits: Vec<u32> = (0..8).map(|_| inp.next_bit()).collect();
+        assert_eq!(bits, vec![1, 0, 1, 1, 0, 0, 1, 0]);
+
+        let mut inp2 = CpInput::new(&[0b1100_1010, 0b1111_0000]);
+        assert_eq!(inp2.next_bits(4), 0b1100);
+        assert_eq!(inp2.next_bits(4), 0b1010);
+        assert_eq!(inp2.next_bits(8), 0b1111_0000);
+    }
+
+    /// `buffer_offset()` (XAD's `currbyte`) must equal `ceil(consumed_bits/8)`
+    /// at every step — the LZH inter-block padding skip depends on this exact
+    /// accounting. Validated independently of any real archive.
+    #[test]
+    fn cpinput_byte_offset_is_ceil_of_consumed_bits() {
+        let data = [0xAC, 0x35, 0xFF, 0x00, 0x42];
+        let mut inp = CpInput::new(&data);
+        for k in 1..=(data.len() as u32 * 8) {
+            let _ = inp.next_bit();
+            assert_eq!(
+                inp.buffer_offset(),
+                k.div_ceil(8) as i64,
+                "after consuming {k} bits"
+            );
+        }
+    }
+
+    /// Skipping to the byte boundary rounds the position up to the next byte,
+    /// and a subsequent byte read lands on that byte — the exact sequence the
+    /// block-transition code performs before parsing a new block header.
+    #[test]
+    fn cpinput_skip_to_byte_boundary_then_byte_read_aligns() {
+        let mut inp = CpInput::new(&[0xAB, 0xCD, 0xEF, 0x12]);
+        for _ in 0..3 {
+            inp.next_bit();
+        }
+        assert_eq!(inp.buffer_offset(), 1, "3 bits -> ceil = byte 1");
+        inp.skip_to_byte_boundary();
+        assert_eq!(inp.buffer_offset(), 1, "boundary holds at byte 1");
+        assert_eq!(inp.next_byte(), Some(0xCD), "byte read resumes at byte 1");
+        assert_eq!(inp.buffer_offset(), 2);
+        // skip_bytes advances exactly, matching the +2/+3 padding skip.
+        inp.skip_bytes(1);
+        assert_eq!(inp.next_byte(), Some(0x12));
+    }
+
+    /// A single-symbol Huffman code (one length-1 symbol) decodes that symbol.
+    #[test]
+    fn huff_single_symbol() {
+        let mut lengths = vec![0i32; 4];
+        lengths[2] = 1; // symbol 2, code length 1
+        let huff = Huff::build(&lengths).expect("valid code");
+        let mut input = CpInput::new(&[0x00]);
+        assert_eq!(huff.decode(&mut input), Some(2));
+    }
+
+    /// The per-file CRC covers `resource ++ data`; an empty file checksums to
+    /// the bare seed, and order matters (rsrc before data).
+    #[test]
+    fn verify_entry_crc_covers_rsrc_then_data() {
+        // Empty entry: seed value, as seen on Compact Pro's `Icon` placeholder.
+        assert!(verify_entry_crc(&[], &[], 0xffff_ffff).is_ok());
+
+        let rsrc = b"RSRC-BYTES";
+        let data = b"DATA-BYTES";
+        let expected = crc32_update(crc32_update(0xffff_ffff, rsrc), data);
+        assert!(verify_entry_crc(rsrc, data, expected).is_ok());
+        // Swapped order must not validate.
+        assert!(verify_entry_crc(data, rsrc, expected).is_err());
+        // A bit flip is caught.
+        assert!(verify_entry_crc(rsrc, data, expected ^ 1).is_err());
+    }
+
+    /// Over-subscribed code lengths are rejected rather than producing a
+    /// corrupt table.
+    #[test]
+    fn huff_rejects_oversubscribed() {
+        // Three length-1 codes cannot coexist (only two 1-bit codes exist).
+        let lengths = vec![1, 1, 1];
+        assert!(Huff::build(&lengths).is_none());
+    }
+}

--- a/src/macarchive/detect.rs
+++ b/src/macarchive/detect.rs
@@ -23,6 +23,7 @@ use std::io::Cursor;
 use crate::fs::binhex;
 use crate::rbformats::dc42;
 
+use super::compactpro::is_compactpro;
 use super::extract::is_stuffitx;
 use super::stuffit::{find_sea_archive, is_stuffit};
 use super::stuffit5::is_stuffit5;
@@ -49,6 +50,11 @@ pub enum MacArchiveKind {
     /// A self-extracting StuffIt archive: a Mac application carrying a
     /// SIT! signature inside its data fork.
     Sea,
+    /// A Compact Pro archive (`.cpt`, or a `.sea` self-extracting one). The
+    /// `0x01` marker plus a CRC-validated index identify it.
+    CompactPro,
+    /// A `.cpt.hqx` / `.sea.hqx`: BinHex-wrapped Compact Pro archive.
+    BinHexOverCompactPro,
 }
 
 impl MacArchiveKind {
@@ -63,6 +69,8 @@ impl MacArchiveKind {
             MacArchiveKind::Sit => "StuffIt",
             MacArchiveKind::Sit5 => "StuffIt 5",
             MacArchiveKind::Sea => "SEA",
+            MacArchiveKind::CompactPro => "Compact Pro",
+            MacArchiveKind::BinHexOverCompactPro => "Compact-Pro-over-BinHex",
         }
     }
 
@@ -74,6 +82,7 @@ impl MacArchiveKind {
             MacArchiveKind::BinHexSingleFile
                 | MacArchiveKind::BinHexOverSit
                 | MacArchiveKind::BinHexOverSea
+                | MacArchiveKind::BinHexOverCompactPro
         )
     }
 
@@ -103,6 +112,9 @@ pub fn detect_mac_archive(bytes: &[u8]) -> Option<MacArchiveKind> {
         if is_stuffit(inner) || is_stuffit5(inner) {
             return Some(MacArchiveKind::BinHexOverSit);
         }
+        if is_compactpro(inner) {
+            return Some(MacArchiveKind::BinHexOverCompactPro);
+        }
         if find_sea_archive(inner).is_some() {
             return Some(MacArchiveKind::BinHexOverSea);
         }
@@ -124,6 +136,9 @@ pub fn detect_mac_archive(bytes: &[u8]) -> Option<MacArchiveKind> {
         // the file as-is; the existing extractor bails with a clearer
         // message when they try to expand it.
         return None;
+    }
+    if is_compactpro(bytes) {
+        return Some(MacArchiveKind::CompactPro);
     }
     if find_sea_archive(bytes).is_some() {
         return Some(MacArchiveKind::Sea);

--- a/src/macarchive/extract.rs
+++ b/src/macarchive/extract.rs
@@ -2,6 +2,7 @@
 //! and the GUI archive-browse tab.
 
 use anyhow::{bail, Context, Result};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use crate::fs::binhex;
@@ -79,6 +80,16 @@ pub fn open_bytes(raw: Vec<u8>) -> Result<(Vec<u8>, StuffItArchive)> {
             let bh = binhex::parse_binhex(&raw)?;
             parse_sit_family(bh.data_fork)
         }
+        Some(MacArchiveKind::BinHexOverCompactPro) => {
+            // Peel the HQX, then parse the inner Compact Pro archive.
+            let bh = binhex::parse_binhex(&raw)?;
+            let archive = super::compactpro::parse(&bh.data_fork)?;
+            Ok((bh.data_fork, archive))
+        }
+        Some(MacArchiveKind::CompactPro) => {
+            let archive = super::compactpro::parse(&raw)?;
+            Ok((raw, archive))
+        }
         Some(MacArchiveKind::Sit) | Some(MacArchiveKind::Sit5) | Some(MacArchiveKind::Sea) => {
             parse_sit_family(raw)
         }
@@ -131,19 +142,23 @@ fn synth_single_file_archive(bh: binhex::BinHexFile) -> (Vec<u8>, StuffItArchive
         mod_date: 0,
         data: Some(stuffit::ForkInfo {
             method: 0,
+            codec: stuffit::ForkCodec::StuffIt,
             encrypted: false,
             uncompressed_len: data_len,
             compressed_len: data_len,
             crc: data_crc,
+            crc32: 0,
             offset: 0,
         }),
         rsrc: if rsrc_len > 0 {
             Some(stuffit::ForkInfo {
                 method: 0,
+                codec: stuffit::ForkCodec::StuffIt,
                 encrypted: false,
                 uncompressed_len: rsrc_len,
                 compressed_len: rsrc_len,
                 crc: rsrc_crc,
+                crc32: 0,
                 offset: data_len as u64,
             })
         } else {
@@ -200,15 +215,31 @@ pub fn extract_filtered(
         .enumerate()
         .filter(|(i, e)| !e.is_dir && keep(*i))
         .count();
+
+    // Raw format only: an entry's resource fork is written to a `name.rsrc`
+    // sidecar, which collides when a *sibling* entry is literally named
+    // `name.rsrc` (e.g. classic THINK projects ship `Foo.pi` alongside a
+    // `Foo.pi.rsrc` resource file). Reserve every data-fork destination up
+    // front so sidecars dodge them — data-fork names always keep their
+    // natural path, sidecars yield to a non-colliding `.rsrc.N` variant.
+    let reserved_data_paths: HashSet<PathBuf> = if format == ForkFormat::Raw {
+        archive
+            .entries
+            .iter()
+            .enumerate()
+            .filter(|(i, e)| !e.is_dir && keep(*i))
+            .map(|(_, e)| entry_target(dest, e))
+            .collect()
+    } else {
+        HashSet::new()
+    };
+    let mut used_sidecars: HashSet<PathBuf> = HashSet::new();
+
     let mut stats = ExtractStats::default();
     let mut done = 0usize;
 
     for (idx, e) in archive.entries.iter().enumerate() {
-        let mut rel = PathBuf::new();
-        for comp in &e.path {
-            rel.push(sanitize_filename(comp));
-        }
-        let target = dest.join(&rel);
+        let target = entry_target(dest, e);
 
         if e.is_dir {
             // Always create directory markers — a subsequent kept file
@@ -240,11 +271,53 @@ pub fn extract_filtered(
             }
         };
 
-        write_entry(&target, e, &data, &rsrc, format)?;
+        // Compact Pro stores one CRC-32 per file over (resource fork ++ data
+        // fork); verify it now that both forks are decompressed. This is the
+        // format's only integrity check, so it covers single-fork, dual-fork,
+        // and empty entries alike.
+        if let Some(expected) = compactpro_entry_crc(e) {
+            if let Err(err) = super::compactpro::verify_entry_crc(&rsrc, &data, expected) {
+                log(format!("Skipped {}: {err}", e.display_path()));
+                stats.skipped += 1;
+                continue;
+            }
+        }
+
+        // Resolve the raw resource-fork sidecar path, dodging any sibling
+        // data fork that already owns `name.rsrc`. Other formats prefix the
+        // sidecar (`._name`) or change its extension (`.hqx` / `.bin`), so
+        // they never collide and pass `None`.
+        let raw_rsrc_path = if format == ForkFormat::Raw && !rsrc.is_empty() {
+            let natural = with_added_extension(&target, "rsrc");
+            let chosen = raw_rsrc_sidecar_path(&target, &reserved_data_paths, &mut used_sidecars);
+            if chosen != natural {
+                log(format!(
+                    "Note: resource fork of '{}' written as '{}' to avoid overwriting a sibling file named '{}'",
+                    e.display_path(),
+                    chosen.file_name().unwrap_or_default().to_string_lossy(),
+                    natural.file_name().unwrap_or_default().to_string_lossy(),
+                ));
+            }
+            Some(chosen)
+        } else {
+            None
+        };
+
+        write_entry(&target, e, &data, &rsrc, format, raw_rsrc_path.as_deref())?;
         stats.files += 1;
     }
 
     Ok(stats)
+}
+
+/// The per-file CRC-32 for a Compact Pro entry (carried identically on both
+/// forks), or `None` for StuffIt entries which checksum each fork on decode.
+fn compactpro_entry_crc(e: &StuffItEntry) -> Option<u32> {
+    [e.rsrc.as_ref(), e.data.as_ref()]
+        .into_iter()
+        .flatten()
+        .find(|f| matches!(f.codec, stuffit::ForkCodec::CompactPro { .. }))
+        .map(|f| f.crc32)
 }
 
 fn decompress_named(
@@ -254,24 +327,38 @@ fn decompress_named(
     log: &mut impl FnMut(String),
 ) -> Result<Vec<u8>, ()> {
     match fork {
-        Some(f) if f.uncompressed_len > 0 => match stuffit::decompress_fork(bytes, f) {
-            Ok(d) => Ok(d),
-            Err(err) => {
-                log(format!("Skipped {}: {err}", e.display_path()));
-                Err(())
+        Some(f) if f.uncompressed_len > 0 => {
+            let result = match f.codec {
+                stuffit::ForkCodec::StuffIt => stuffit::decompress_fork(bytes, f),
+                stuffit::ForkCodec::CompactPro { .. } => {
+                    super::compactpro::decompress_fork(bytes, f)
+                }
+            };
+            match result {
+                Ok(d) => Ok(d),
+                Err(err) => {
+                    log(format!("Skipped {}: {err}", e.display_path()));
+                    Err(())
+                }
             }
-        },
+        }
         _ => Ok(Vec::new()),
     }
 }
 
 /// Write one extracted file's forks to the host in the chosen container format.
+///
+/// `raw_rsrc_path` overrides where a [`ForkFormat::Raw`] resource sidecar is
+/// written; the orchestrator passes a collision-free path here (see
+/// [`raw_rsrc_sidecar_path`]). It is ignored for every other format, and a
+/// `None` falls back to the natural `name.rsrc` next to `target`.
 pub fn write_entry(
     target: &Path,
     entry: &StuffItEntry,
     data: &[u8],
     rsrc: &[u8],
     format: ForkFormat,
+    raw_rsrc_path: Option<&Path>,
 ) -> Result<()> {
     match format {
         ForkFormat::BinHex => {
@@ -309,11 +396,46 @@ pub fn write_entry(
         ForkFormat::Raw => {
             std::fs::write(target, data)?;
             if !rsrc.is_empty() {
-                std::fs::write(with_added_extension(target, "rsrc"), rsrc)?;
+                let rsrc_dst = raw_rsrc_path
+                    .map(Path::to_path_buf)
+                    .unwrap_or_else(|| with_added_extension(target, "rsrc"));
+                std::fs::write(rsrc_dst, rsrc)?;
             }
         }
     }
     Ok(())
+}
+
+/// Destination path for an entry's data fork: `dest` joined with the entry's
+/// path components, each [`sanitize_filename`]d. Shared by the extraction loop
+/// and the up-front data-path reservation so both agree on every name.
+fn entry_target(dest: &Path, entry: &StuffItEntry) -> PathBuf {
+    let mut rel = PathBuf::new();
+    for comp in &entry.path {
+        rel.push(sanitize_filename(comp));
+    }
+    dest.join(rel)
+}
+
+/// Pick a raw resource-fork sidecar path that won't clobber any data fork.
+/// The natural name is `<target>.rsrc`; if a different entry's data fork
+/// already owns that path (it's in `reserved`) or a previous sidecar took it
+/// (`used`), fall back to `<target>.rsrc.1`, `.2`, ... until free. Records the
+/// chosen path in `used` so two sidecars can't collide either.
+fn raw_rsrc_sidecar_path(
+    target: &Path,
+    reserved: &HashSet<PathBuf>,
+    used: &mut HashSet<PathBuf>,
+) -> PathBuf {
+    let base = with_added_extension(target, "rsrc");
+    let mut candidate = base.clone();
+    let mut n = 1u32;
+    while reserved.contains(&candidate) || used.contains(&candidate) {
+        candidate = with_added_extension(&base, &n.to_string());
+        n += 1;
+    }
+    used.insert(candidate.clone());
+    candidate
 }
 
 /// Append `.ext` to a path (keeping any existing extension).
@@ -457,6 +579,63 @@ mod tests {
             "file2 should be skipped"
         );
         assert!(dir.path().join("subdir/file3.txt").exists());
+    }
+
+    /// Raw extraction must not lose a resource fork when a sibling entry is
+    /// literally named `<name>.rsrc` and would otherwise overwrite the
+    /// sidecar. The data fork of the `.rsrc`-named file keeps its natural
+    /// path; the colliding resource fork is parked at `<name>.rsrc.1`.
+    /// (Reproduces the macppp `ppp.pi` / `ppp.pi.rsrc` data loss from the
+    /// real archive.)
+    #[test]
+    fn raw_extract_preserves_forks_on_dot_rsrc_name_collision() {
+        use super::super::stuffit::{build_archive_tree, StuffItInputNode, WriteMethod};
+        let mk = |name: &str, data: &[u8], rsrc: &[u8]| super::super::stuffit::StuffItInput {
+            name: name.into(),
+            type_code: [0; 4],
+            creator_code: [0; 4],
+            finder_flags: 0,
+            create_date: 0,
+            mod_date: 0,
+            data_fork: data.to_vec(),
+            resource_fork: rsrc.to_vec(),
+        };
+        // `Doc` carries a resource fork; `Doc.rsrc` is a *separate* file
+        // whose data fork would land on `Doc`'s sidecar path.
+        let tree = vec![
+            StuffItInputNode::File(mk("Doc", b"DOC-DATA", b"DOC-RSRC")),
+            StuffItInputNode::File(mk("Doc.rsrc", b"SIBLING-DATA", b"")),
+        ];
+        let arc_bytes = build_archive_tree(&tree, WriteMethod::Store).expect("build");
+        let (bytes, archive) = open_bytes(arc_bytes).expect("open");
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let stats = extract_all(
+            &bytes,
+            &archive,
+            dir.path(),
+            ForkFormat::Raw,
+            |_, _, _| {},
+            |_| {},
+        )
+        .expect("extract");
+        assert_eq!(stats.files, 2);
+        assert_eq!(stats.skipped, 0);
+
+        // The sibling file's data fork keeps `Doc.rsrc` intact.
+        assert_eq!(
+            std::fs::read(dir.path().join("Doc.rsrc")).unwrap(),
+            b"SIBLING-DATA",
+            "sibling data fork must not be clobbered"
+        );
+        // `Doc`'s data fork is untouched.
+        assert_eq!(std::fs::read(dir.path().join("Doc")).unwrap(), b"DOC-DATA");
+        // `Doc`'s resource fork survives at the de-conflicted sidecar.
+        assert_eq!(
+            std::fs::read(dir.path().join("Doc.rsrc.1")).unwrap(),
+            b"DOC-RSRC",
+            "Doc resource fork must be preserved at a non-colliding path"
+        );
     }
 
     /// `open_bytes` on truly opaque bytes returns the new

--- a/src/macarchive/mod.rs
+++ b/src/macarchive/mod.rs
@@ -7,10 +7,13 @@
 //!
 //! - [`stuffit`] — classic StuffIt (`.sit`, `SIT!` magic) and StuffIt
 //!   self-extracting archives (`.sea`).
+//! - [`compactpro`] — Compact Pro (`.cpt`, and `.sea` self-extracting),
+//!   commonly distributed BinHex-wrapped.
 //!
 //! See `docs/native_mac_archives.md` for the format references and roadmap.
 
 pub mod bitreader_be;
+pub mod compactpro;
 pub mod detect;
 pub mod extract;
 pub mod stuffit;

--- a/src/macarchive/stuffit.rs
+++ b/src/macarchive/stuffit.rs
@@ -48,27 +48,52 @@ const END_FOLDER: u8 = 0x21;
 /// folder marker (or the raw method) behind.
 const FOLDER_MASK: u8 = !(ENCRYPTED_FLAG | FOLDER_CONTAINS_ENCRYPTED);
 
-/// One fork (data or resource) of a StuffIt entry.
+/// Which decompressor a [`ForkInfo`] needs. StuffIt and Compact Pro share the
+/// same entry/fork plumbing (the directory tree in [`StuffItEntry`] and every
+/// output format in `extract`) but use entirely different fork codecs and
+/// checksums, so the codec tag picks the right decompressor at extract time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForkCodec {
+    /// StuffIt method lives in [`ForkInfo::method`]; checksum is the
+    /// CRC-16/ARC in [`ForkInfo::crc`].
+    StuffIt,
+    /// Compact Pro (`super::compactpro`): byte-level RLE, optionally preceded
+    /// by an LZH (LZSS + Huffman) layer. Compact Pro stores one CRC-32 per
+    /// file (in [`ForkInfo::crc32`]) over the resource fork followed by the
+    /// data fork, so it's verified once per entry rather than per fork.
+    CompactPro { lzh: bool },
+}
+
+/// One fork (data or resource) of a StuffIt or Compact Pro entry.
 #[derive(Debug, Clone)]
 pub struct ForkInfo {
-    /// Compression method (low nibble: 0=none, 1=RLE90, 3=Huffman, 13=LZ+Huffman, 15=Arsenic, …).
+    /// StuffIt compression method (low nibble: 0=none, 1=RLE90, 3=Huffman,
+    /// 13=LZ+Huffman, 15=Arsenic, …). Ignored for [`ForkCodec::CompactPro`].
     pub method: u8,
+    /// Which codec decompresses this fork.
+    pub codec: ForkCodec,
     /// True when the fork is password-encrypted (not supported for extraction).
     pub encrypted: bool,
     /// Decompressed length in bytes.
     pub uncompressed_len: u32,
     /// Compressed length in bytes (as stored in the archive).
     pub compressed_len: u32,
-    /// Stored CRC-16/ARC of the decompressed fork.
+    /// Stored CRC-16/ARC of the decompressed fork (StuffIt forks only).
     pub crc: u16,
+    /// Stored CRC-32 of the decompressed fork (Compact Pro forks only).
+    pub crc32: u32,
     /// Absolute byte offset of the compressed data within the archive.
     pub offset: u64,
 }
 
 impl ForkInfo {
-    /// Human-readable compression method name.
+    /// Human-readable compression method name, codec-aware.
     pub fn method_name(&self) -> &'static str {
-        method_name(self.method)
+        match self.codec {
+            ForkCodec::StuffIt => method_name(self.method),
+            ForkCodec::CompactPro { lzh: true } => "Compact Pro (LZH+RLE)",
+            ForkCodec::CompactPro { lzh: false } => "Compact Pro (RLE)",
+        }
     }
 }
 
@@ -235,10 +260,12 @@ pub fn parse(data: &[u8]) -> Result<StuffItArchive> {
         let rsrc = if rsrc_len > 0 || rsrc_clen > 0 {
             Some(ForkInfo {
                 method: rmethod & !ENCRYPTED_FLAG,
+                codec: ForkCodec::StuffIt,
                 encrypted: rmethod & ENCRYPTED_FLAG != 0,
                 uncompressed_len: rsrc_len,
                 compressed_len: rsrc_clen,
                 crc: rsrc_crc,
+                crc32: 0,
                 offset: data_start,
             })
         } else {
@@ -246,10 +273,12 @@ pub fn parse(data: &[u8]) -> Result<StuffItArchive> {
         };
         let data = Some(ForkInfo {
             method: dmethod & !ENCRYPTED_FLAG,
+            codec: ForkCodec::StuffIt,
             encrypted: dmethod & ENCRYPTED_FLAG != 0,
             uncompressed_len: data_len,
             compressed_len: data_clen,
             crc: data_crc,
+            crc32: 0,
             offset: data_start + rsrc_clen as u64,
         });
 

--- a/src/macarchive/stuffit5.rs
+++ b/src/macarchive/stuffit5.rs
@@ -11,7 +11,7 @@
 use anyhow::{bail, Result};
 use std::collections::HashMap;
 
-use super::stuffit::{ForkInfo, StuffItArchive, StuffItEntry};
+use super::stuffit::{ForkCodec, ForkInfo, StuffItArchive, StuffItEntry};
 
 const SIT5_MAGIC: &[u8] = b"StuffIt (c)1997";
 const SIT5_ID: u32 = 0xA5A5_A5A5;
@@ -229,10 +229,12 @@ pub fn parse(data: &[u8]) -> Result<StuffItArchive> {
             let rsrc = if has_resource && (resourcelength > 0 || resourcecomplen > 0) {
                 Some(ForkInfo {
                     method: resourcemethod,
+                    codec: ForkCodec::StuffIt,
                     encrypted: false,
                     uncompressed_len: resourcelength,
                     compressed_len: resourcecomplen,
                     crc: resourcecrc,
+                    crc32: 0,
                     offset: datastart,
                 })
             } else {
@@ -240,10 +242,12 @@ pub fn parse(data: &[u8]) -> Result<StuffItArchive> {
             };
             let data_fork = Some(ForkInfo {
                 method: datamethod,
+                codec: ForkCodec::StuffIt,
                 encrypted: false,
                 uncompressed_len: datalength,
                 compressed_len: datacomplen,
                 crc: datacrc,
+                crc32: 0,
                 offset: datastart + resourcecomplen as u64,
             });
             entries.push(StuffItEntry {

--- a/src/model/file_types.rs
+++ b/src/model/file_types.rs
@@ -26,9 +26,10 @@ pub const DISK_IMAGE_EXTS: &[&str] = &[
 /// Optical disc-image extensions (CD/DVD images), a distinct picker group.
 pub const OPTICAL_EXTS: &[&str] = &["iso", "bin", "cue", "chd", "toast", "img"];
 
-/// Macintosh archive / encoding extensions (StuffIt + BinHex), a picker group
-/// for the Archives tab. Includes uppercase variants for case-sensitive pickers.
-pub const MAC_ARCHIVE_EXTS: &[&str] = &["sit", "hqx", "sea", "SIT", "HQX", "SEA"];
+/// Macintosh archive / encoding extensions (StuffIt + Compact Pro + BinHex), a
+/// picker group for the Archives tab. Includes uppercase variants for
+/// case-sensitive pickers; new entries are lowercase-only (`cpt`).
+pub const MAC_ARCHIVE_EXTS: &[&str] = &["sit", "hqx", "sea", "cpt", "SIT", "HQX", "SEA"];
 
 /// ProgId registered under `HKCU\Software\Classes` for disk-image associations.
 pub const DISK_IMAGE_PROGID: &str = "RustyBackup.DiskImage";
@@ -89,6 +90,19 @@ mod tests {
             assert!(
                 association_exts().contains(&must.to_string()),
                 "missing X68000 HDD extension {must}"
+            );
+        }
+    }
+
+    #[test]
+    fn mac_archive_family_present() {
+        // StuffIt (.sit/.sea), BinHex (.hqx), and Compact Pro (.cpt) all flow
+        // through `macarchive` detection + the Archives tab. Pin them so a
+        // picker-list cleanup can't silently drop a supported archive format.
+        for must in ["sit", "hqx", "sea", "cpt"] {
+            assert!(
+                MAC_ARCHIVE_EXTS.contains(&must),
+                "missing Mac archive extension {must}"
             );
         }
     }


### PR DESCRIPTION
…k collision

Compact Pro support
-------------------
New `compactpro.rs` reads Bill Goodman's Compact Pro archives (`.cpt`, the self-extracting `.sea`, and their BinHex-wrapped `.hqx` forms) — a common vintage-Mac distribution format we previously mis-handled as a single opaque file. Port of XADMaster's XADCompactPro{Parser,RLEHandle,LZHHandle}: a byte-level RLE layer optionally fed by an LZH (LZSS + canonical Huffman, 8 KB window, 0x1fff0-count blocks with inter-block padding).

Compact Pro reuses the existing StuffIt entry tree and all four extract output formats via a new `ForkCodec` tag on `ForkInfo` (StuffIt | CompactPro). The format stores one CRC-32 per file over `resource_fork ++ data_fork`, verified once per entry in `extract_filtered` (covers single-, dual-, and empty-fork files). Wired into content detection (`CompactPro` / `BinHexOverCompactPro` kinds), the GUI archive-import dialog, `rb-cli sit list/extract`, and the `MAC_ARCHIVE_EXTS` picker group.

Validated byte-identical to `unar` on two real archives: single-block (MacTCP206.sea) and multi-block (Dunjin44.cpt.hqx, whose 150 KB text fork spans three LZH blocks). Regression test runs against the latter when present.

Raw-extract fork collision fix
------------------------------
`sit extract --format raw` wrote a resource fork to `name.rsrc`, which silently clobbered a sibling entry literally named `name.rsrc` (e.g. THINK projects ship `Foo.pi` alongside `Foo.pi.rsrc`). Data-fork target paths are now reserved up front and colliding sidecars fall back to `name.rsrc.1` with a logged note. Verified against the real macppp archive; regression test added.