### PR TITLE
Publish rb-cli-mini via MiSTer Downloader custom database

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -885,11 +885,79 @@ jobs:
           tar -tzf "$TGZ"
           ls -lh "$TGZ"
 
+      - name: Build MiSTer Downloader database (custom-databases.md)
+        env:
+          VER: ${{ needs.generate-version.outputs.version }}
+        run: |
+          # MiSTer Downloader (Downloader_MiSTer) consumes a custom-database JSON
+          # that lists individual files -> SD paths with an md5 + size each; it
+          # does NOT unpack tarballs. So alongside the .tar.gz we publish the raw
+          # binary + daemon shim as standalone, UN-versioned release assets plus a
+          # `*.json.zip` database that points at them through GitHub's stable
+          # `releases/latest/download/<asset>` alias. Stable names + the `latest`
+          # alias = one fixed db_url the user adds once; every later release's
+          # fresh hashes line up because the user always fetches the newest DB.
+          set -e
+          mkdir -p dist-mister
+          cp target/armv7-unknown-linux-gnueabihf/release/rb-cli dist-mister/rb-cli-mini-armv7
+          cp "$GITHUB_WORKSPACE/mister/rb-daemon.sh"            dist-mister/rb-daemon.sh
+
+          BIN_MD5=$(md5sum dist-mister/rb-cli-mini-armv7 | cut -d' ' -f1)
+          BIN_SIZE=$(stat -c%s dist-mister/rb-cli-mini-armv7)
+          SH_MD5=$(md5sum dist-mister/rb-daemon.sh | cut -d' ' -f1)
+          SH_SIZE=$(stat -c%s dist-mister/rb-daemon.sh)
+          TS=$(date +%s)
+          BASE="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/latest/download"
+
+          # db_id is permanent once published - changing it strands old files on
+          # users' cards (Downloader can no longer clean them up). Keep it forever.
+          cat > dist-mister/rusty-backup.json <<JSON
+          {
+            "v": 1,
+            "db_id": "danifunker/rusty-backup",
+            "timestamp": ${TS},
+            "files": {
+              "Scripts/rb-cli": {
+                "hash": "${BIN_MD5}",
+                "size": ${BIN_SIZE},
+                "url": "${BASE}/rb-cli-mini-armv7",
+                "overwrite": true,
+                "reboot": false
+              },
+              "Scripts/rb-daemon.sh": {
+                "hash": "${SH_MD5}",
+                "size": ${SH_SIZE},
+                "url": "${BASE}/rb-daemon.sh",
+                "overwrite": true,
+                "reboot": false
+              }
+            },
+            "folders": {
+              "Scripts/": {}
+            }
+          }
+          JSON
+
+          # Downloader accepts a zipped DB as long as the name ends `.json.zip`;
+          # the JSON filename inside the zip is free-form.
+          ( cd dist-mister && zip -q rusty-backup.json.zip rusty-backup.json )
+
+          echo "----- generated MiSTer Downloader database -----"
+          cat dist-mister/rusty-backup.json
+          ls -lh dist-mister/
+
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: rb-cli-mini-armv7-linux-${{ needs.generate-version.outputs.version }}
-          path: rb-cli-mini-armv7-linux-${{ needs.generate-version.outputs.version }}.tar.gz
+          # The versioned tarball is the human download; the un-versioned
+          # dist-mister/ files are what the Downloader database references via the
+          # `releases/latest/download/` alias. The release job flattens both out.
+          path: |
+            rb-cli-mini-armv7-linux-${{ needs.generate-version.outputs.version }}.tar.gz
+            dist-mister/rb-cli-mini-armv7
+            dist-mister/rb-daemon.sh
+            dist-mister/rusty-backup.json.zip
 
   # Turn the `appliance` choice input into a JSON arch list for the matrix
   # below. A manual dispatch honours none / i586 / i686 / both. A push to
@@ -1126,7 +1194,11 @@ jobs:
       - name: Flatten artifacts
         run: |
           mkdir -p release-files
-          find artifacts -type f \( -name "*.zip" -o -name "*.dmg" -o -name "*.AppImage" -o -name "*.AppImage.zsync" -o -name "*.deb" -o -name "*.rpm" -o -name "*.pkg.tar.zst" -o -name "*.exe" -o -name "*.tar.gz" -o -name "*.iso" -o -name "*.img" \) -exec cp {} release-files/ \;
+          # `rusty-backup.json.zip` matches the *.zip glob; the raw MiSTer
+          # Downloader assets (no extension / *.sh) are named explicitly so they
+          # ship as standalone, un-versioned release assets the database can hit
+          # via `releases/latest/download/`.
+          find artifacts -type f \( -name "*.zip" -o -name "*.dmg" -o -name "*.AppImage" -o -name "*.AppImage.zsync" -o -name "*.deb" -o -name "*.rpm" -o -name "*.pkg.tar.zst" -o -name "*.exe" -o -name "*.tar.gz" -o -name "*.iso" -o -name "*.img" -o -name "rb-cli-mini-armv7" -o -name "rb-daemon.sh" \) -exec cp {} release-files/ \;
           ls -lh release-files/
       
       # Build a download-picker table from the (fixed) build matrix. Links
@@ -1139,6 +1211,10 @@ jobs:
         run: |
           TAG="v${VER}"
           BASE="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}"
+          # Stable, version-independent URL for the MiSTer Downloader database:
+          # the `latest` alias always resolves to the newest non-prerelease, so
+          # users add this db_url once and pick up every future build.
+          DB_URL="https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/rusty-backup.json.zip"
           # Warn (don't fail) if an expected asset is missing — surfaces a
           # matrix change without blocking the release.
           for f in \
@@ -1153,6 +1229,7 @@ jobs:
             "rb-cli-macos-arm64-${VER}.zip" "rb-cli-macos-x64-${VER}.zip" \
             "rb-cli-linux-x64-${VER}.tar.gz" "rb-cli-linux-arm64-${VER}.tar.gz" \
             "rb-cli-mini-armv7-linux-${VER}.tar.gz" \
+            "rb-cli-mini-armv7" "rb-daemon.sh" "rusty-backup.json.zip" \
             "rusty-backup-appliance-i586-${VER}.iso" "rusty-backup-appliance-i686-${VER}.iso" \
             "rusty-backup-appliance-pxe-i586-${VER}.tar.gz" "rusty-backup-appliance-pxe-i686-${VER}.tar.gz" \
             "rusty-backup-grub-floppy-i586-${VER}.img" "rusty-backup-grub-floppy-i686-${VER}.img" \
@@ -1176,6 +1253,17 @@ jobs:
           | **MiSTer FPGA** (Cortex-A9, glibc 2.31) | armv7 hardfloat | _(GUI not built for this target)_ | [rb-cli-mini](${BASE}/rb-cli-mini-armv7-linux-${VER}.tar.gz) |
 
           <sub>**Windows:** x86 = 32-bit (Windows 10, the last Windows with 32-bit support). · **macOS:** requires 10.13 High Sierra or later. · **Linux:** deb = Debian/Ubuntu, rpm = Fedora/RHEL/openSUSE, pkg = Arch/Manjaro; the packages and \`rb-cli\` are built against **glibc 2.39** (Ubuntu 24.04), while the **AppImage** is self-contained and runs on most distributions regardless of glibc. · **MiSTer FPGA:** \`rb-cli-mini\` is a slim \`rb-cli\` cross-compiled for the MiSTer's armv7 hardfloat Intel Cyclone V SoC against Ubuntu 20.04 glibc 2.31 — same baseline as the MiSTer Buildroot rootfs and the upstream \`libchdman-rs\` armv7 prebuilt. GUI/optical features are off; CHD is in. Drop it onto the SD at \`/media/fat/Scripts/rb-cli\`. · Every **rb-cli** download contains a single \`rb-cli\` executable (\`rb-cli.exe\` on Windows).</sub>
+
+          ### Install on a MiSTer FPGA (one line, auto-updating)
+
+          MiSTer users don't need the tarball: add Rusty Backup to the **MiSTer Downloader** as a custom database and it installs (and keeps itself updated) from the Scripts/Update menu. Add this section to \`/media/fat/downloader.ini\` on the SD card:
+
+          \`\`\`ini
+          [danifunker/rusty-backup]
+          db_url = '${DB_URL}'
+          \`\`\`
+
+          Then run **Scripts > update** (or **Downloader**) on the MiSTer. It drops \`rb-cli\` and \`rb-daemon.sh\` into \`/media/fat/Scripts\`. Open **rb-daemon** from the Scripts menu to start the network daemon and enable it on boot. The \`db_url\` points at the \`latest\` release, so each future Downloader run picks up new builds automatically. (Prefer to do it by hand? The \`rb-cli-mini-...tar.gz\` above still works via its bundled \`install.sh\`.)
 
           ### Boot the vintage machine itself (Linux appliance)
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,36 @@ without the `optical` feature" message):
 Full background and the feature matrix live in
 [`docs/mister_cli.md`](docs/mister_cli.md).
 
+#### Install via MiSTer Downloader (custom database)
+
+The easiest way to get Rusty Backup onto a MiSTer is the built-in
+**Downloader** (the same tool `update_all` drives). It installs and
+**keeps itself updated** from the Scripts menu — no SSH, no tarball, no
+cross toolchain. Add this section to `/media/fat/downloader.ini` on the
+SD card:
+
+```ini
+[danifunker/rusty-backup]
+db_url = 'https://github.com/danifunker/rusty-backup/releases/latest/download/rusty-backup.json.zip'
+```
+
+Then run **Scripts > update** (or **Downloader**) on the MiSTer. It
+drops `rb-cli` and `rb-daemon.sh` into `/media/fat/Scripts`. The
+`db_url` points at the `latest` release, so every later Downloader run
+picks up new builds automatically.
+
+This is a [MiSTer Downloader *custom database*](https://github.com/MiSTer-devel/Downloader_MiSTer/blob/main/docs/custom-databases.md):
+each release's CI publishes the slim armv7 binary and the daemon shim as
+standalone assets plus a generated `rusty-backup.json.zip` database that
+references them by md5 + size. Because Downloader places individual files
+(it doesn't unpack tarballs), the bare `rb-cli` may arrive without its
+executable bit — `rb-daemon.sh` re-applies it on first run, so the menu
+entry works regardless.
+
+Prefer to install by hand? The `rb-cli-mini-...tar.gz` from the
+[Releases page](https://github.com/danifunker/rusty-backup/releases) still
+ships its own `install.sh` (see below).
+
 #### Run this device as a network daemon (rb-daemon)
 
 The MiSTer build can run as a small **network daemon** so the desktop

--- a/mister/rb-daemon.sh
+++ b/mister/rb-daemon.sh
@@ -18,6 +18,14 @@ set -e
 DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 RB_CLI="$DIR/rb-cli"
 
+# When delivered by MiSTer Downloader (a custom database), the binary can arrive
+# without the executable bit set. install.sh chmods it, but the Downloader path
+# skips install.sh, so set it here too - this keeps the menu entry working with
+# no manual chmod regardless of how rb-cli got onto the card.
+if [ -f "$RB_CLI" ] && [ ! -x "$RB_CLI" ]; then
+    chmod +x "$RB_CLI" 2>/dev/null || true
+fi
+
 if [ ! -x "$RB_CLI" ]; then
     echo "rb-cli was not found next to rb-daemon.sh:"
     echo "  $RB_CLI"


### PR DESCRIPTION
## What

Lets MiSTer users install — and **auto-update** — Rusty Backup straight from the on-device **Scripts > update** / Downloader menu, instead of unpacking the release tarball by hand.

MiSTer Downloader consumes a [custom-database JSON](https://github.com/MiSTer-devel/Downloader_MiSTer/blob/main/docs/custom-databases.md) that places *individual files* at SD-card paths by md5 + size — it does **not** unpack tarballs. So this teaches the release pipeline to publish exactly that.

## How users install

Add one section to `/media/fat/downloader.ini`, then run **Scripts > update**:

```ini
[danifunker/rusty-backup]
db_url = 'https://github.com/danifunker/rusty-backup/releases/latest/download/rusty-backup.json.zip'
```

Downloader drops `rb-cli` and `rb-daemon.sh` into `/media/fat/Scripts`. The `db_url` resolves through the `latest` release alias, so every future Downloader run picks up new builds automatically.

## Changes

- **`.github/workflows/release.yml`**
  - `build-rb-cli-mini-armv7` job emits the raw `rb-cli-mini-armv7` binary and `rb-daemon.sh` as standalone, **un-versioned** release assets (so the `releases/latest/download/<asset>` alias resolves them) plus a generated `rusty-backup.json.zip` database (v1, `db_id: danifunker/rusty-backup`) mapping `Scripts/rb-cli` and `Scripts/rb-daemon.sh` to them with computed md5 + size and `overwrite: true`.
  - The release job flattens the new assets into the release, warns if any are missing, and adds a ready-to-paste `downloader.ini` snippet to the auto-generated release notes.
- **`mister/rb-daemon.sh`** — `chmod +x` the binary on first run. Downloader delivers files individually and doesn't preserve the executable bit (`install.sh` set it, but the Downloader path skips `install.sh`).
- **`README.md`** — new "Install via MiSTer Downloader (custom database)" section.

## Notes / decisions

- **Stable `db_id`** is hardcoded (`danifunker/rusty-backup`). The spec requires it to *never* change once published — hardcoding protects against a future repo rename, which would otherwise strand files on users' cards.
- Did **not** use [`DB-Template_MiSTer`](https://github.com/theypsilon/DB-Template_MiSTer): it expects the payload committed into a separate repo, duplicating the binary. Generating the DB in the existing release pipeline keeps one source of truth.
- Assets only publish on push to `main` (release job gates on `main`/`master`), so the `latest/download/...` URL goes live after the first release builds post-merge.

## Verification

- Workflow YAML parses.
- Simulated the DB-generation bash with a dummy binary: emits valid JSON, real MD5 hashes, correct `.json.zip`.
- Simulated the release-notes heredoc: escaped backticks stay literal, `db_url` expands.
- `bash -n` clean on `rb-daemon.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)