### PR TITLE
feat(mister): optical-disc ripping in the rb-cli-mini armv7 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -822,7 +822,7 @@ jobs:
       - name: Install cross
         run: cargo install cross --git https://github.com/cross-rs/cross --locked
 
-      - name: Build rb-cli-mini for MiSTer armv7 (CHD on, GUI / optical off)
+      - name: Build rb-cli-mini for MiSTer armv7 (CHD + optical on, GUI off)
         env:
           RELEASE_VERSION: ${{ needs.generate-version.outputs.version }}
           # libchdman-rs's build.rs falls back to $HOME/.cache/libchdman-rs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -840,12 +840,17 @@ jobs:
           # libchdman-rs armv7 prebuilt.
           # `remote` = the rb-cli serve daemon + rb:// (pure std::net + serde_json,
           # no C / no extra crate), so the MiSTer can host its images on the LAN.
+          # `optical` = CD/DVD ripping (`optical rip` / `drives` / `convert`).
+          # cd-da-reader is cc+libc (an SG_IO shim, no system libcdio); opticaldiscs
+          # (>=0.4.5) reuses the SAME libchdman-rs 0.288.5 prebuilt as `chd` (deduped
+          # to one copy), which ships an armv7 build. Lets a device with a CD drive
+          # (e.g. SuperStation One) rip discs.
           cross build \
             --bin rb-cli \
             --release \
             --target armv7-unknown-linux-gnueabihf \
             --no-default-features \
-            --features chd,pure-zstd,remote
+            --features chd,pure-zstd,remote,optical
 
       - name: Strip binary
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -274,7 +274,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -305,7 +305,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
  "x11rb",
 ]
 
@@ -886,7 +886,7 @@ dependencies = [
 [[package]]
 name = "cd-da-reader"
 version = "0.4.1"
-source = "git+https://github.com/danifunker/rust-cd-da-reader?branch=add-data-support-0-4-1#33fb7df91ea456cd6f98dc17cb7d4f6ef82575f3"
+source = "git+https://github.com/danifunker/rust-cd-da-reader?branch=add-data-support-0-4-1#75711068f07455e5fed7b700ea0732f807027708"
 dependencies = [
  "cc",
  "libc",
@@ -3985,7 +3985,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4917,7 +4917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5367,7 +5367,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
  "cipher",
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -263,7 +263,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -274,7 +274,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -678,15 +678,6 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
@@ -952,7 +943,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common 0.2.2",
+ "crypto-common",
  "inout",
 ]
 
@@ -1160,15 +1151,6 @@ checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -1252,16 +1234,6 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
@@ -1316,23 +1288,13 @@ checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.2.2",
+ "crypto-common",
  "ctutils",
  "zeroize",
 ]
@@ -1355,7 +1317,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1688,7 +1650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1975,16 +1937,6 @@ dependencies = [
  "pango-sys",
  "pkg-config",
  "system-deps",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -2311,7 +2263,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -2821,20 +2773,6 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libchdman-rs"
-version = "0.287.0-l7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe34138e7c9f2a433bc234c4b5ceba624032bc90b605f68b7680fcc5337057a2"
-dependencies = [
- "cc",
- "hex",
- "libc",
- "sha2 0.10.9",
- "tempfile",
- "ureq 2.12.1",
-]
-
-[[package]]
-name = "libchdman-rs"
 version = "0.288.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23c6f7338dec4f8dd7ae07e2956b5d9633be9b0dd81782aa28b6db3b9239534"
@@ -2842,9 +2780,9 @@ dependencies = [
  "cc",
  "hex",
  "libc",
- "sha2 0.11.0",
+ "sha2",
  "tempfile",
- "ureq 3.3.0",
+ "ureq",
 ]
 
 [[package]]
@@ -2987,7 +2925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -3607,12 +3545,12 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opticaldiscs"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb30e617e9d74619ba827bb8daa06ceea913c0d284c146b36dfb811924e75457"
+checksum = "91726e09312bbe825916a5c1589e9a080d91e6e1fa4f43995c2941c8812f12ab"
 dependencies = [
  "cue_sheet",
- "libchdman-rs 0.287.0-l7",
+ "libchdman-rs",
  "log",
  "thiserror 2.0.18",
 ]
@@ -3720,7 +3658,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
- "digest 0.11.3",
+ "digest",
  "hmac",
 ]
 
@@ -4428,7 +4366,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4487,7 +4425,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4544,7 +4482,7 @@ dependencies = [
  "globset",
  "image",
  "libc",
- "libchdman-rs 0.288.5",
+ "libchdman-rs",
  "libzstd-bitexact-rs",
  "log",
  "lz4_flex",
@@ -4563,7 +4501,7 @@ dependencies = [
  "serde_json",
  "serde_yml",
  "sha1",
- "sha2 0.11.0",
+ "sha2",
  "shell-words",
  "tar",
  "tempfile",
@@ -4774,19 +4712,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -4796,8 +4723,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -4990,7 +4917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5103,7 +5030,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5440,7 +5367,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5484,21 +5411,6 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64",
- "log",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "url",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "ureq"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
@@ -5510,7 +5422,7 @@ dependencies = [
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots 1.0.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5929,15 +5841,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
@@ -6151,7 +6054,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6512,7 +6415,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,8 +94,13 @@ mock_gui = ["dep:eframe", "dep:egui"]
 # off for MiSTer cross-compiles. ADFS / QXL.WIN / .d88 / .adf / .hdf / .vhd /
 # .img / .zst all still work without it.
 chd = ["dep:libchdman-rs"]
-# Physical optical-drive I/O (rip / data-track read). MiSTer has no optical
-# drive; leaving this off also drops a libcdio Buildroot dep.
+# Physical optical-drive I/O (rip / data-track read) plus optical-image
+# convert/browse. Builds on armv7 (MiSTer) too: cd-da-reader is cc+libc
+# (a self-compiled SG_IO shim — NO system libcdio link), and opticaldiscs
+# (>=0.4.5) reuses the SAME libchdman-rs 0.288.5 prebuilt as the `chd` feature
+# — which ships an armv7-gnueabihf-glibc2.31 build — so the two dedupe to one
+# libchdman. At runtime it needs a drive present (e.g. /dev/sr0); harmless to
+# include when none is attached.
 optical = ["dep:opticaldiscs", "dep:cd-da-reader"]
 # Network daemon + client (`rb-cli serve` and `rb://host:port/img@N` refs).
 # ON BY DEFAULT, and every shipped build opts in: the desktop release via

--- a/README.md
+++ b/README.md
@@ -84,24 +84,27 @@ Open CLI follow-ups (and everything else still to do) are tracked in
 `rb-cli-mini` is the **MiSTer-specific** build of `rb-cli`: a slim
 variant cross-compiled for the FPGA's Intel Cyclone V / Cortex-A9 SoC
 (`armv7-unknown-linux-gnueabihf`, glibc 2.31 baseline from the
-Buildroot rootfs). It excludes the GUI (eframe / egui / rfd), the
-optical-disc stack (opticaldiscs / cd-da-reader), and the update
-checker's reqwest client — but **keeps CHD support** via the upstream
-`libchdman-rs` armv7 prebuilt, so `.chd` images work inline on the
-device.
+Buildroot rootfs). It excludes the GUI (eframe / egui / rfd) and the
+update checker's reqwest client — but **keeps CHD support** via the
+upstream `libchdman-rs` armv7 prebuilt (so `.chd` images work inline on
+the device) **and the optical-disc stack** (opticaldiscs / cd-da-reader),
+so devices with a CD/DVD drive (e.g. the SuperStation One) can rip discs
+on-device.
 
 The desktop release builds use the full feature set; only the MiSTer
-artifact runs `--no-default-features --features chd,pure-zstd,remote` (CHD
-via the C prebuilt; zstd via the pure-Rust bit-exact backend, since a cross
-build won't link C libzstd; `remote` for the network daemon — see
-[rb-daemon](#run-this-device-as-a-network-daemon-rb-daemon) below).
+artifact runs `--no-default-features --features chd,pure-zstd,remote,optical`
+(CHD via the C prebuilt; zstd via the pure-Rust bit-exact backend, since a
+cross build won't link C libzstd; `remote` for the network daemon — see
+[rb-daemon](#run-this-device-as-a-network-daemon-rb-daemon) below; `optical`
+for CD/DVD ripping — cd-da-reader is cc+libc with no system libcdio link, and
+opticaldiscs reuses the same libchdman-rs 0.288.5 prebuilt as `chd`).
 
 ```
 # Cross-compile for MiSTer (armv7-unknown-linux-gnueabihf):
 cargo install cross --git https://github.com/cross-rs/cross --locked
 cross build --bin rb-cli --release \
             --target armv7-unknown-linux-gnueabihf \
-            --no-default-features --features chd,pure-zstd,remote
+            --no-default-features --features chd,pure-zstd,remote,optical
 
 # Strip + deploy. The release tarball ships the binary as `rb-cli-mini`;
 # do the local rename here too so the on-MiSTer filename matches the
@@ -138,11 +141,12 @@ What's in the MiSTer build:
   and disks on the LAN so the desktop app can browse/back up/restore them
   over `rb://`. Installs from the Scripts menu; see
   [below](#run-this-device-as-a-network-daemon-rb-daemon).
+- **Optical-disc ripping** (`optical drives` to find the drive, then
+  `optical rip --device /dev/sr0 --format iso|bincue`), plus `optical
+  convert` (ISO ↔ BIN/CUE ↔ CD-CHD) and `optical browse` / `extract`. For
+  devices with a CD/DVD drive such as the SuperStation One.
 
-What's excluded (operations exit with a clear "this binary was built
-without the `optical` feature" message):
-- `optical` verb (rip / disc browse / extract via the OS optical-drive
-  layer — the MiSTer has no optical drive attached).
+What's excluded:
 - GUI windows and the update-checker self-replace UI (only meaningful
   for the desktop binary).
 

--- a/docs/full_MiSTer_support_status.md
+++ b/docs/full_MiSTer_support_status.md
@@ -40,6 +40,12 @@ support the disk types (floppy / hard disk / CD-ROM) of the outstanding cores.
   (bare + Arculator-wrapped), Apple-II `.do` / `.po` / `.dsk` sector-order,
   gzip-wrapped Amiga `.adz` / `.hdz`.
 - **Raw / superfloppy** (partitionless) images are handled.
+- **Optical / CD-ROM:** rip a physical CD/DVD drive to ISO or BIN/CUE
+  (`optical rip`), list drives (`optical drives`), convert ISO <-> BIN/CUE <->
+  CD-CHD (`optical convert`), and browse/extract ISO9660 / Joliet / HFS disc
+  images. Built into the desktop release and — as of opticaldiscs 0.4.5 — the
+  MiSTer `rb-cli-mini` armv7 build, for devices with an attached drive (e.g.
+  the SuperStation One).
 
 Legend for the **Support** column:
 

--- a/docs/mister_cli.md
+++ b/docs/mister_cli.md
@@ -257,7 +257,8 @@ Strip the binary for size:
 
 ```sh
 arm-linux-gnueabihf-strip target/.../rb-cli
-# Expect ~5-8 MB stripped (vs. ~30-40 MB unstripped Rust release).
+# Expect ~15 MB stripped with chd + optical (libchdman's static C++ CHD core
+# dominates; it was ~5-8 MB before CHD/optical were added to the mini build).
 ```
 
 ---

--- a/docs/mister_cli.md
+++ b/docs/mister_cli.md
@@ -164,14 +164,21 @@ native-tls) to `rustls-tls` so there's no openssl-sys dep.
 
 ### 4. `opticaldiscs` / `cd-da-reader` (drives feature)
 
-`opticaldiscs = { version = "0.4.2", features = ["drives"] }` and
-`cd-da-reader` (git fork). These touch real CD drives via system
-APIs (Linux: `libcdio` or `ioctl`). MiSTer has no optical drive
-attached, but the build still compiles them — and `libcdio` may or
-may not be present in the Buildroot rootfs.
+`opticaldiscs` (CHD/ISO/BIN-CUE disc-image browse + drive enum) and
+`cd-da-reader` (physical-drive ripping). The original worry here —
+"`libcdio` may not be present in the Buildroot rootfs" — turned out to
+be unfounded: `cd-da-reader` is `cc` + `libc` only (a self-compiled
+SG_IO `ioctl` shim, **no** system `libcdio` link), and `opticaldiscs`'s
+`drives` feature is pure Rust.
 
-**Resolution: gate behind `optical` feature.** Default on for host
-builds, off for `minimal-cli`. Same shape as `chd`.
+**Resolution (updated 2026-06-26): SHIPPED on armv7.** The real blocker
+was that `opticaldiscs` pinned `libchdman-rs 0.287.0-l7`, which publishes
+no armv7 prebuilt (only x86_64 / aarch64 / apple / windows). `opticaldiscs
+0.4.5` bumps that to `libchdman-rs 0.288.5` — the same version the `chd`
+feature uses, which *does* ship an `armv7-unknown-linux-gnueabihf-glibc2.31`
+prebuilt — so the two dedupe to one libchdman and the optical stack
+cross-compiles. The MiSTer job now builds with `optical` enabled; it stays
+gated behind the `optical` feature (default on for host builds).
 
 ---
 
@@ -351,11 +358,13 @@ Idea captured 2026-06-05 after the Wave-2 Archie engine close-out.
   / GCC 5.4 / glibc 2.23 — too old to have the C++11 `std::thread`
   polymorphic-`_State` symbols the prebuilt depends on, so we pin to
   a digest of the `:main` rolling tag rather than `v0.2.5`.
-- The MiSTer job now builds with `--no-default-features --features chd,pure-zstd`
+- The MiSTer job builds with `--no-default-features --features chd,pure-zstd,remote,optical`
   so the artifact includes CHD support via the libchdman-rs prebuilt (plus the
   pure-Rust zstd backend — exactly one zstd backend is required, and a cross
-  build can't link C libzstd) — the GUI and optical stacks stay out, but `.chd`
-  is in. The job is
+  build can't link C libzstd), the rb-daemon (`remote`), and the optical stack
+  (`optical` — CD/DVD ripping; requires opticaldiscs >= 0.4.5 so both it and
+  `chd` share the armv7 libchdman-rs 0.288.5 prebuilt). Only the GUI stays out.
+  The job is
   marked `continue-on-error: true` and is intentionally OUT of the
   `release` job's `needs:` list, so a transient cross-compile failure
   (or the timing window while upstream libchdman-rs armv7 prebuilt is

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -248,7 +248,7 @@ pub enum Command {
         cmd: verbs::show::ShowCommand,
     },
 
-    /// Optical-media verbs (rip / convert / browse / extract).
+    /// Optical-media verbs (drives / rip / convert / browse / extract).
     #[cfg(feature = "optical")]
     Optical {
         #[command(subcommand)]

--- a/src/cli/verbs/optical.rs
+++ b/src/cli/verbs/optical.rs
@@ -3,14 +3,15 @@
 //! `src/optical/`.
 //!
 //! Subcommands:
+//! - `drives` — list connected physical optical drives
 //! - `rip` — rip a physical disc to ISO or BIN/CUE
 //! - `convert` — re-encode an optical image (ISO ↔ BIN/CUE ↔ CHD)
 //! - `browse` — list files on an optical image (ISO9660 / Joliet / HFS)
 //! - `extract` — extract files from an optical image to a host folder
 //!
-//! The GUI's interactive drive picker has no terminal equivalent; pass
-//! `--device PATH` explicitly. `rb-cli show devices` can help locate
-//! the right path on the host.
+//! The GUI's interactive drive picker has no terminal equivalent; run
+//! `rb-cli optical drives` to find a drive path, then pass it as
+//! `--device PATH` to `rip`.
 
 use anyhow::{bail, Context, Result};
 use clap::{Args, Subcommand, ValueEnum};
@@ -29,6 +30,8 @@ use crate::rbformats::chd_options::{ChdOptions, ChdProfile};
 
 #[derive(Debug, Subcommand)]
 pub enum OpticalCommand {
+    /// List connected physical optical drives and their device paths.
+    Drives,
     /// Rip a physical CD/DVD drive to a disk image file.
     Rip(RipArgs),
     /// Re-encode an optical image into a different format.
@@ -41,11 +44,31 @@ pub enum OpticalCommand {
 
 pub fn run(cmd: OpticalCommand) -> Result<()> {
     match cmd {
+        OpticalCommand::Drives => run_drives_verb(),
         OpticalCommand::Rip(a) => run_rip_verb(a),
         OpticalCommand::Convert(a) => run_convert_verb(a),
         OpticalCommand::Browse(a) => run_browse_verb(a),
         OpticalCommand::Extract(a) => run_extract_verb(a),
     }
+}
+
+// ---------------- drives ----------------
+
+/// List physical optical drives, mirroring the GUI Optical tab's drive picker
+/// (`opticaldiscs::drives::list_drives`). Prints one drive per line to stdout as
+/// `<device-path>  <display-name>` so the path can be fed to `optical rip
+/// --device`. ASCII only (no glyphs) per the project's terminal-output rule.
+fn run_drives_verb() -> Result<()> {
+    let drives = opticaldiscs::drives::list_drives();
+    if drives.is_empty() {
+        log_stderr("No optical drives found.");
+        return Ok(());
+    }
+    log_stderr(format!("Found {} optical drive(s):", drives.len()));
+    for d in &drives {
+        println!("{}  {}", d.device_path.display(), d.display_name);
+    }
+    Ok(())
 }
 
 // ---------------- rip ----------------

--- a/src/optical/mod.rs
+++ b/src/optical/mod.rs
@@ -1,3 +1,6 @@
+// `browse_view` is an egui widget; it only exists in GUI builds. The CLI/mini
+// build enables `optical` without `gui`, so gate it to keep that build green.
+#[cfg(feature = "gui")]
 pub mod browse_view;
 pub mod convert;
 pub mod rip;


### PR DESCRIPTION
Enables CD/DVD ripping on MiSTer-family devices with an attached optical drive (e.g. the **SuperStation One**) by turning on the existing `optical` feature for the armv7 `rb-cli-mini` cross-build.

## What changed here
- **`release.yml`**: armv7 mini build features `chd,pure-zstd,remote` → `chd,pure-zstd,remote,optical`.
- **`src/optical/mod.rs`**: gate the egui-only `browse_view` behind `gui` so `optical` compiles without the GUI (the mini build's shape).
- **`src/cli/verbs/optical.rs`**: new `rb-cli optical drives` — lists connected drives + device paths (mirrors the GUI drive picker via `opticaldiscs::drives::list_drives`).
- **`Cargo.lock`**: `opticaldiscs` 0.4.4 → **0.4.5**, which **drops `libchdman-rs 0.287.0-l7` entirely** and dedupes onto the single `0.288.5` the `chd` feature already uses; and `cd-da-reader` → the armv7 SG_IO fix.
- Docs synced: README MiSTer section, `mister_cli.md`, `full_MiSTer_support_status.md`.

## The blocker chain (both fixed upstream, in sibling repos)
1. **`opticaldiscs` pinned `libchdman-rs 0.287.0-l7`**, which publishes no armv7 prebuilt. → Published **opticaldiscs 0.4.5** bumping it to `0.288.5` (which *does* ship `armv7-…-gnueabihf-glibc2.31.a`). Zero source changes — the CHD API surface is identical across the two.
2. **`cd-da-reader` had a 32-bit-portability bug**: `const SG_IO: u64` doesn't fit `libc::ioctl`'s `c_ulong` request param (32-bit on armv7). → Fixed in `rust-cd-da-reader@7571106` (typed `c_ulong`).

The "needs libcdio" worry from the old docs was unfounded — `cd-da-reader` is just a `cc`+`libc` SG_IO shim.

## Validation
`build-rb-cli-mini-armv7` CI job is **green**. ELF verify on the armv7 binary:
- `NEEDED` = `ld-linux-armhf / libc / libdl / libgcc_s / libm / libpthread / libstdc++` — **no `libcdio`**.
- Max symbol `GLIBC_2.28` (< MiSTer's 2.31) → runs on-device.
- Stripped binary ~15 MB; tarball + MiSTer Downloader DB entry produced.

rusty-backup's own desktop CHD stack is unchanged (still libchdman-rs 0.288.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)