### PR TITLE
UI tweaks: recent-files pickers, dropdown sizing, remote copy, fork export

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1246,21 +1246,34 @@ jobs:
             [ -f "$f" ] || continue
             sudo sed -i -E 's|^deb (http)|deb [arch=amd64] \1|; s|^deb-src (http)|deb-src [arch=amd64] \1|' "$f"
           done
-          # Release pocket ONLY (no -updates/-security/-backports). The ports
-          # mirror propagates SRUs to riscv64 out of step with amd64, so a
-          # security update to e.g. libglib2.0-dev can land its new package
-          # split (libglib2.0-dev-bin-linux) before the matching riscv64
-          # binaries exist, leaving apt with "held broken packages". The
-          # release snapshot is internally consistent, which is all a
-          # throwaway cross sysroot needs.
+          # Keep every pocket (noble + -updates/-security/-backports): libc6 is
+          # Multi-Arch: same, so libc6:riscv64 must EXACTLY match the runner's
+          # already-installed libc6:amd64, which comes from -security/-updates.
+          # Dropping those pockets makes libc6:riscv64 uninstallable and every
+          # sysroot lib collapses with "libc6:riscv64 ... not installable".
           printf '%s\n' \
             'Types: deb' \
             'URIs: http://ports.ubuntu.com/ubuntu-ports' \
-            'Suites: noble' \
+            'Suites: noble noble-updates noble-backports noble-security' \
             'Components: main universe' \
             'Architectures: riscv64' \
             'Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg' \
             | sudo tee /etc/apt/sources.list.d/riscv64-ports.sources >/dev/null
+          # ...but the ports mirror propagates SRUs to riscv64 out of step with
+          # amd64. A libglib2.0 security update (2.80.0-6ubuntu3.8) landed a new
+          # package split (libglib2.0-dev-bin-linux) whose riscv64 binary didn't
+          # exist yet, so apt hit "held broken packages" on libglib2.0-dev.
+          # Forbid the glib packages from the SRU pockets so they resolve from
+          # the internally-consistent release snapshot; libc6 etc. stay current.
+          printf '%s\n' \
+            'Package: libglib2.0*' \
+            'Pin: release a=noble-updates' \
+            'Pin-Priority: -10' \
+            '' \
+            'Package: libglib2.0*' \
+            'Pin: release a=noble-security' \
+            'Pin-Priority: -10' \
+            | sudo tee /etc/apt/preferences.d/riscv64-glib-release.pref >/dev/null
           sudo apt-get update
 
       - name: Install riscv64 cross toolchain + GTK/GL sysroot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1279,12 +1279,31 @@ jobs:
       - name: Install riscv64 cross toolchain + GTK/GL sysroot
         run: |
           set -euxo pipefail
-          # python3-packaging is Architecture: all / Multi-Arch: foreign. The
-          # release libglib2.0-dev-bin depends on it; without the native copy
-          # present apt tries to pull python3-packaging:riscv64 (which drags the
-          # whole riscv64 python stack and isn't installable). Installing the
-          # native one lets it satisfy the foreign dep directly.
-          sudo apt-get install -y python3-packaging
+          # The release libglib2.0-dev-bin depends on python3-packaging, which
+          # is Architecture: all but NOT Multi-Arch: foreign, so the cross
+          # libglib2.0-dev-bin:riscv64 can't be satisfied by the native copy and
+          # apt demands an (uninstallable) python3-packaging:riscv64. A Rust
+          # cross-build never runs glib's python dev tools (glib-mkenums,
+          # gdbus-codegen), so stand in a riscv64 stub that Provides it.
+          sudo apt-get install -y equivs
+          cat > /tmp/glib-py-stub.ctl <<'CTL'
+          Section: misc
+          Priority: optional
+          Standards-Version: 3.9.2
+          Package: glib-py-packaging-stub
+          Version: 1.0
+          Architecture: riscv64
+          Provides: python3-packaging
+          Description: Stub satisfying libglib2.0-dev-bin's python3-packaging dep
+           python3-packaging (Architecture: all, not Multi-Arch: foreign) can't
+           satisfy the cross libglib2.0-dev-bin:riscv64 dependency. A Rust
+           cross-build never runs glib's python dev tools, so this empty
+           Provides package is a safe stand-in.
+          CTL
+          # heredoc is indented for YAML; strip the leading whitespace back off.
+          sed -i 's/^          //' /tmp/glib-py-stub.ctl
+          ( cd /tmp && equivs-build --arch riscv64 glib-py-stub.ctl )
+          sudo dpkg -i /tmp/glib-py-packaging-stub_1.0_riscv64.deb
           sudo apt-get install -y \
             g++-riscv64-linux-gnu binutils-riscv64-linux-gnu file \
             libgtk-3-dev:riscv64 libglib2.0-dev:riscv64 \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1246,10 +1246,17 @@ jobs:
             [ -f "$f" ] || continue
             sudo sed -i -E 's|^deb (http)|deb [arch=amd64] \1|; s|^deb-src (http)|deb-src [arch=amd64] \1|' "$f"
           done
+          # Release pocket ONLY (no -updates/-security/-backports). The ports
+          # mirror propagates SRUs to riscv64 out of step with amd64, so a
+          # security update to e.g. libglib2.0-dev can land its new package
+          # split (libglib2.0-dev-bin-linux) before the matching riscv64
+          # binaries exist, leaving apt with "held broken packages". The
+          # release snapshot is internally consistent, which is all a
+          # throwaway cross sysroot needs.
           printf '%s\n' \
             'Types: deb' \
             'URIs: http://ports.ubuntu.com/ubuntu-ports' \
-            'Suites: noble noble-updates noble-backports noble-security' \
+            'Suites: noble' \
             'Components: main universe' \
             'Architectures: riscv64' \
             'Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg' \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1279,6 +1279,12 @@ jobs:
       - name: Install riscv64 cross toolchain + GTK/GL sysroot
         run: |
           set -euxo pipefail
+          # python3-packaging is Architecture: all / Multi-Arch: foreign. The
+          # release libglib2.0-dev-bin depends on it; without the native copy
+          # present apt tries to pull python3-packaging:riscv64 (which drags the
+          # whole riscv64 python stack and isn't installable). Installing the
+          # native one lets it satisfy the foreign dep directly.
+          sudo apt-get install -y python3-packaging
           sudo apt-get install -y \
             g++-riscv64-linux-gnu binutils-riscv64-linux-gnu file \
             libgtk-3-dev:riscv64 libglib2.0-dev:riscv64 \

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,110 @@
+# Release Notes
+
+This release adds **native Macintosh archive support** (BinHex + StuffIt, no
+emulator required), a complete **XFS check / repair / edit** stack for vintage
+IRIX disks, and a new **Archives** tab in the GUI — plus CLI verbs for all of
+it.
+
+## Native Mac archives (BinHex & StuffIt)
+
+Decode and create the classic Mac fork-preserving archive formats end-to-end,
+without launching an emulator. Both forks (data + resource) and full Finder
+info (type/creator/flags) are preserved throughout.
+
+- **BinHex 4.0 (`.hqx`)** — native encode **and** decode (CRC-16-CCITT, RLE90,
+  6-bit alphabet).
+- **StuffIt classic (`.sit`)** and **self-extracting (`.sea`)** — reader with
+  per-fork decompression for methods:
+  - 0 — None (stored)
+  - 1 — RLE90
+  - 2 — LZW ("Compress")
+  - 3 — Huffman
+  - 5 — LZAH
+  - 13 — LZ + Huffman
+  - 15 — Arsenic (BWT + arithmetic coder)
+- **StuffIt 5 (`.sit`)** — reader, including the Arsenic (method 15) codec.
+- **StuffIt write** — create archives with stored + RLE90 compression. Writing
+  to a `.hqx` output produces the classic **`.sit.hqx`** (StuffIt wrapped in
+  BinHex), validated against `unar`.
+- **StuffIt X (`.sitx`)** — detected and reported with a clear "not supported"
+  message rather than failing obscurely (decoding is out of scope for now).
+
+Decoded payloads chain into the existing pipeline — an `.hqx`/`.sit` wrapping a
+DiskCopy 4.2 / NDIF image flows straight into HFS/HFS+ browse, inspect, backup,
+and restore.
+
+### GUI — new "Archives" tab
+
+Pick a StuffIt (`.sit` / `.sea`, classic or StuffIt 5) or BinHex-wrapped
+`.sit.hqx` archive, view its entries, and extract them all to a folder in a
+chosen fork-preserving container: **BinHex / MacBinary / AppleDouble / raw**.
+Read-only; all decode logic is shared with the CLI.
+
+### CLI — new verbs
+
+- `rb-cli sit list ARCHIVE` — list entries in a `.sit` / `.sea` / `.sit.hqx`.
+- `rb-cli sit extract ARCHIVE DEST` — unpack an archive to a folder.
+- `rb-cli sit create OUT[.sit|.hqx] FILE...` — build a StuffIt archive from
+  host files (`.hqx`, `.bin`, or plain); a `.hqx` output BinHex-wraps it.
+- `rb-cli put-binhex IMG[@N] HOST.hqx` — decode a BinHex document into a
+  filesystem.
+- `rb-cli get-binhex IMG[@N] SRC OUT.hqx` — extract a file from a filesystem
+  and encode it as BinHex 4.0, preserving both forks + Finder info.
+
+## XFS filesystem: check, repair, and edit
+
+First-class support for SGI IRIX **XFS** volumes (v4 and v5 on-disk formats),
+including read, a multi-phase `fsck`-style verifier, in-place repair, and
+editing. XFS is wired into the APM `Apple_UNIX_SVR2` dispatch for read + edit.
+
+### Verifier (`fsck`)
+
+- **Phase 1** — superblock + per-AG header (AGF/AGI/AGFL) consistency, including
+  secondary-superblock replica checks.
+- **Phase 2** — inode-btree walk + whole-volume block-ownership map
+  (double-allocation and extent-past-volume detection).
+- **Phase 3** — directory connectivity + orphan detection.
+- Free-space btree walk cross-checked against AGF `freeblks`
+  (`AgfFreeblksMismatch`), free-block-vs-inode cross-check (`FreeBlockClaimed`),
+  and full ownership-map accounting (`UnaccountedBlocks`).
+- Validated against a Docker-based `mkfs.xfs`/`xfs_repair` oracle, including a
+  real IRIX V1-inode disk.
+
+### Repair
+
+- **R2** — live free-space (bno/cnt) btree rebuild.
+- **R3** — inode btree (inobt): in-place free-mask/freecount repair **and**
+  full single- and multi-level structure rebuild.
+- **R4** — rewrite damaged secondary superblocks from the primary.
+- **R4b** — recompute corrupt AGF/AGI summary counts.
+- **R5** — recompute inode-core `di_nblocks` / `di_nextents` from the extent
+  list.
+- **R6** — drop dangling short-form directory entries.
+- **R7** — recompute inode link counts from the directory graph, and reconnect
+  orphaned inodes into `/lost+found`.
+
+### Editing
+
+- Allocate inodes/blocks and **create files** (single- and multi-extent, into
+  fragmented free space) and **directories**.
+- **Delete** entries from short-form and single-block directories, freeing the
+  inode and its blocks.
+- Automatic **short-form → single-block directory conversion** when a directory
+  outgrows the inline form.
+
+### Tooling
+
+- New examples: `xfs_check`, `xfs_mkdir`, `xfs_mkfile`.
+- Oracle harness: `scripts/xfs-oracle.sh`.
+- Plans/docs: `docs/xfs_fsck.md`, `docs/xfs_edit_and_repair.md`,
+  `docs/native_mac_archives.md`.
+
+## Fixes & infrastructure
+
+- **32-bit Windows (i686) CI** is green again. The XFS test fixture is a 512 MiB
+  volume; the repair round-trip tests no longer hold two copies at once
+  (read-only pre-checks now borrow the image), and the i686 test binary runs
+  single-threaded so concurrent large fixtures can't exhaust the ~2 GiB 32-bit
+  address space. No test coverage was dropped from either target.
+- A 512 MiB HFS resize-overflow unit test is gated to 64-bit hosts (the logic
+  under test is pointer-width-independent).

--- a/docs/add_10_7_macos.md
+++ b/docs/add_10_7_macos.md
@@ -1,0 +1,175 @@
+# Building rb-cli for vintage Intel Macs (down to macOS 10.7)
+
+Scope: a headless **`rb-cli`** binary for old **64-bit Intel** Macs. The GUI is
+out — `eframe` → `winit` + `wgpu`/`glow` needs a Metal-capable, modern-ish macOS,
+so old Intel hardware is CLI-only. This is the macOS sibling of the exotic-target
+work in [`docs/linux_486_build.md`](linux_486_build.md) (i486/i586 appliance) and
+the armv7/MiSTer slim build.
+
+## The two hard cliffs
+
+Intel Macs span 2006–2020. Rust draws two hard lines through that range:
+
+1. **32-bit Core Solo/Duo (2006–07, capped at 10.6.8)** — needs
+   `i386`/`i686-apple-darwin`, which Rust **removed years ago**
+   (`i686-apple-darwin` went away around Rust 1.42). No modern-Rust build exists.
+   That is a C-offshoot situation (à la `cb-dos`), **not** rb-cli. Out of scope.
+
+2. **64-bit Intel** — the floor is set by Rust's prebuilt `std` for
+   `x86_64-apple-darwin`, which is compiled for **macOS 10.12 (Sierra)**.
+
+Confirmed on this repo's toolchain (Homebrew rustc 1.96.0):
+
+```
+$ rustc --print deployment-target --target x86_64-apple-darwin
+MACOSX_DEPLOYMENT_TARGET=10.12
+```
+
+Modern rustc does not merely default to 10.12 — it **actively refuses** to go
+lower. Passing a smaller target yields:
+
+```
+warning: deployment target in MACOSX_DEPLOYMENT_TARGET was set to 10.7,
+         but the minimum supported by `rustc` is 10.12
+```
+
+It warns and clamps, so a 1.96 binary is stamped 10.12 and **won't load on
+Lion** regardless of the env var.
+
+## Tiers
+
+| Tier | macOS range | Toolchain | Effort |
+| ---- | ----------- | --------- | ------ |
+| **A — Sierra+** | 10.12 (2016) → 12 Monterey (last Intel macOS) | stable, prebuilt std | one env var |
+| **B — Lion–El Capitan** | 10.7 – 10.11 | pinned old Rust **or** nightly build-std + polyfill | hard, best-effort |
+
+**Tier A is the whole game for "vintage Intel."** It covers every Intel Mac
+anyone realistically still backs up disks on (2016+):
+
+```bash
+MACOSX_DEPLOYMENT_TARGET=10.12 \
+  cargo build --release --bin rb-cli \
+  --target x86_64-apple-darwin \
+  --no-default-features --features pure-zstd,remote
+```
+
+Slim (`--no-default-features`) for the same reason as MiSTer/486: `chd`/`optical`
+pull in the `libchdman-rs` / `opticaldiscs` **prebuilts, compiled against a modern
+macOS SDK**, which won't honor an old floor. `pure-zstd` keeps zstd pure-Rust;
+`native-zlib` stays off so flate2 uses its pure-Rust `rust_backend`. You get
+FAT/HFS/HFS+/exFAT/NTFS/Amiga/etc. read+write+backup (zstd/raw/vhd) — everything
+except CHD and physical optical.
+
+## Why 10.7 (Tier B) is hard
+
+The baseline jumped **straight from 10.7 to 10.12 in Rust 1.74** (Nov 2023). The
+documented trigger: std started calling **`clock_gettime`**, which macOS didn't
+add until **10.12 Sierra** (a couple of other 10.12-era primitives are involved
+too, but `clock_gettime` is the canonical one). A 1.96 binary references a symbol
+Lion's `libSystem` doesn't export, so it fails at **dyld load time — before
+`main`**.
+
+Consequence: **10.7, 10.8, 10.9, 10.10, 10.11 are all equally hard** — they're
+all "below 10.12." Picking 10.9 or 10.11 buys nothing. The real choice is binary:
+do you cross the 10.12 line or not?
+
+## Path A — pin Rust 1.73.0 (recommended for Tier B)
+
+**1.73.0 is the last toolchain whose prebuilt `x86_64-apple-darwin` std targets
+10.7** and uses the old `mach_absolute_time`/pthread code paths — no
+`clock_gettime`. That means **no `build-std`, no nightly, no polyfills**. CI:
+
+```yaml
+  build-macos-vintage:
+    runs-on: macos-latest          # arm64 host cross-compiles x86_64 fine
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.73.0
+        with:
+          targets: x86_64-apple-darwin
+      - name: Build (vintage Intel, 10.7 floor)
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "10.7"
+        run: |
+          cargo +1.73.0 build --release --bin rb-cli \
+            --target x86_64-apple-darwin \
+            --no-default-features --features pure-zstd,remote
+```
+
+The one real cost is **dependency MSRV archaeology**. The current `Cargo.lock`
+resolved against 1.96; some crates will demand newer-than-1.73. Reactive loop:
+
+```bash
+cargo +1.73.0 build ...            # fails: "package X requires rustc 1.80"
+cargo update -p X --precise <older-version>   # pin down to a 1.73-OK release
+# repeat until it builds
+```
+
+Usual MSRV offenders to watch: `pure-zstd` (`libzstd-bitexact-rs`), `crossterm`,
+`time`, and anything on `edition2024`. If a crate has **no** 1.73-compatible
+version that still carries the features we need, that's a genuine wall → Path B.
+Keep these pins isolated (a dedicated branch / `rust-toolchain.toml` / separate
+lockfile) so they don't drag the main toolchain backward.
+
+## Path B — nightly + custom target + polyfill (only if Path A's deps won't cooperate)
+
+The macOS analog of `targets/i486-unknown-linux-gnu.json` — best-effort, expect
+CI iteration:
+
+1. **Custom target JSON** (`targets/x86_64-apple-darwin-10.7.json`) overriding the
+   min-OS version below rustc's 10.12 clamp — the target spec is where the floor
+   lives.
+2. **Nightly + `-Z build-std=std,panic_abort`** to recompile std against the
+   lowered target.
+3. **A `clock_gettime` polyfill** (a `.c`/`.o` linked in that implements
+   `clock_gettime` over `gettimeofday`/`mach_absolute_time`) so the weak-linked
+   symbol resolves on Lion instead of crashing — plus anything else the symbol
+   dump below turns up.
+
+More maintenance; keeps the modern dep tree. Reach for it only if 1.73 pinning
+hits a wall.
+
+## Ground-truth loop (run on the artifact, either path)
+
+A **dependency** — not just std — can also call a 10.12 symbol. After any vintage
+build, enumerate the gap:
+
+```bash
+otool -L rb-cli                                # dylib deps: all should be /usr/lib/libSystem etc.
+otool -l rb-cli | grep -A3 LC_BUILD_VERSION    # confirm minos = 10.7 (not clamped to 10.12)
+nm -u rb-cli | sort                            # every undefined import
+# diff against a real 10.7 libSystem symbol list; clock_gettime / os_unfair_lock*
+# / __ulock_* showing up = still broken.
+```
+
+Clean of 10.12-era symbols + `minos` reads 10.7 ⇒ it'll run on Lion.
+
+## Signing / notarization gotcha
+
+The current macOS CI job signs + notarizes with **hardened runtime**. Do **not**
+apply that to the vintage artifact:
+
+- Notarization/Gatekeeper enforcement only exists on **10.14.5+/10.15+** — a
+  Sierra/Lion user never sees it.
+- Hardened-runtime + stapling assumes newer-OS behavior and can make the binary
+  **fail to launch** on the old OS.
+
+So for the vintage variant: **ad-hoc sign (`codesign -s -`) or ship unsigned**,
+and tell users to `xattr -dr com.apple.quarantine ./rb-cli` on first run.
+
+## Local prototyping caveat
+
+This repo's Homebrew rustc is **stable-only, single-toolchain**, ships only the
+host (arm64) std, and actively refuses sub-10.12 targets — so none of Tier B can
+be prototyped locally as-is. To work on it locally, install `rustup`
+(`brew install rustup` → `rustup-init`), then either
+`rustup toolchain install 1.73.0` (Path A) or a nightly + the `rust-src`
+component (Path B). Otherwise it's a CI-only exercise.
+
+## Recommendation
+
+Ship **Tier A** now (slim `x86_64-apple-darwin` rb-cli, `MACOSX_DEPLOYMENT_TARGET
+=10.12`, ad-hoc signed) as a step on the existing Intel macOS job — near-zero
+maintenance, covers 2016+. Treat **Tier B (10.7–10.11)** as a follow-up branch
+like i486: try Path A (Rust 1.73.0) first; fall back to Path B only if a
+dependency has no 1.73-compatible version. Skip 32-bit entirely.

--- a/docs/bump_opticaldiscs.md
+++ b/docs/bump_opticaldiscs.md
@@ -1,0 +1,180 @@
+# Bump `opticaldiscs` to 0.5.0 (breaking change + latent-bug fix)
+
+> **Task prompt** for a Claude Code session working in this repo
+> (`rusty-backup`). Self-contained: follow it top to bottom, then run the
+> verification steps before reporting done. All line numbers below are
+> approximate — `rg` for the symbols rather than trusting them.
+
+## Goal
+
+Bump the `opticaldiscs` dependency from `0.4.2` to **`0.5`** and update the
+optical-disc browse/extract code for the one breaking API change. This is
+gated behind the `optical` feature, so build and test **with `--features optical`**
+or the breakage won't surface.
+
+> Note: rusty-backup pins `opticaldiscs = "0.4.2"`, i.e. `^0.4.2` (`<0.5.0`), so
+> nothing is broken today — this is a deliberate forward bump.
+
+## Why bump (two reasons, both real)
+
+1. **Fixes a latent extraction bug in *this* repo** (see "The bug" below): the
+   optical AppleDouble / MacBinary export currently corrupts the Finder
+   type/creator for any non-printable 4-byte code, because it rebuilds those
+   bytes from opticaldiscs' *display string*. 0.5.0 exposes the raw bytes, which
+   fixes it and lets us delete the `fourcc` reparse helpers.
+2. **Decoding correctness for optical HFS browsing**: 0.5.0 fixes a shifted Mac OS
+   Roman table (bytes ≥ 0x9B mis-decoded: `ü`→`†`, `©`→`™`, etc.) and makes HFS+
+   UTF-16 name decoding lenient (a single bad code unit no longer drops the whole
+   entry from the listing). This only affects the *opticaldiscs-backed* optical
+   path — rusty-backup's own `src/fs/hfs*` code already has the correct table.
+
+## The breaking API change
+
+`FileEntry::type_code` / `FileEntry::creator_code` changed type:
+
+```text
+        before (0.4.x):  Option<String>          // display string, lossy for high-bit codes
+        after  (0.5.0):  Option<[u8; 4]>          // raw Finder bytes, verbatim
+```
+
+New in 0.5.0:
+
+- `FileEntry::type_code_string()` / `creator_code_string()` → `Option<String>` —
+  the *exact* old display rendering (`"TEXT"`, or `"0x12345678"` for
+  non-printable codes). Use these wherever you only display the code.
+- `FileEntry::finder_flags: Option<u16>` — `FInfo.fdFlags` (`isAlias 0x8000`,
+  `isInvisible 0x4000`, `hasBundle 0x2000`, `hasCustomIcon 0x0400`). Optional to use.
+
+Nothing else rusty-backup imports from opticaldiscs changed
+(`DiscFormat`, `DiscImageInfo`, `SectorReader`, `BinCueSectorReader`,
+`bincue::parse_cue_tracks`, `browse::*`, `drives::list_drives`, the `drives`
+feature) — so the break is localized to the `type_code`/`creator_code` reads.
+
+## The bug (why the extraction edits matter)
+
+`src/cli/verbs/optical.rs:fourcc(Option<&str>)` and
+`src/optical/browse_view.rs:fourcc_bytes(&str)` both just copy the first 4 bytes
+of opticaldiscs' display string into a `[u8; 4]`. For a high-bit creator code
+like Prince of Persia's `50 6F C4 50`, opticaldiscs 0.4.x returns the hex
+fallback string `"0x506FC450"`, so `fourcc` produces `b"0x50"` —
+**a wrong type/creator written into the AppleDouble/MacBinary.** Printable codes
+(`"TEXT"`) happen to round-trip; non-printable ones are silently corrupted.
+
+With 0.5.0 the raw bytes are available directly, so the `fourcc`/`fourcc_bytes`
+reparse is both unnecessary and the source of the bug — delete it and use
+`entry.type_code` straight.
+
+## Required edits
+
+### 1. `Cargo.toml`
+
+```toml
+opticaldiscs = { version = "0.5", features = ["drives"], optional = true }
+```
+
+> If `opticaldiscs` 0.5.0 isn't on crates.io yet when you do this, use the local
+> checkout for testing and flip back to the crates.io version once published:
+>
+> ```toml
+> opticaldiscs = { path = "../opticaldiscs-rs", features = ["drives"], optional = true }
+> ```
+
+Then run `cargo tree -i libchdman-rs` and confirm opticaldiscs 0.5.0 and
+rusty-backup's direct `libchdman-rs` dependency still resolve to a **single**
+copy; reconcile the pin if they diverge.
+
+### 2. Display sites → use `*_string()`
+
+These format the code with `{tc}` / `format!("Type: {tc}")`, which no longer
+works on `[u8; 4]`.
+
+- `src/cli/verbs/optical.rs` (~396–401), tree listing:
+
+  ```rust
+  if let Some(tc) = child.type_code_string() {
+      out.push_str(&format!("  {tc}"));
+      if let Some(cc) = child.creator_code_string() {
+          out.push_str(&format!("/{cc}"));
+      }
+  }
+  ```
+
+- `src/optical/browse_view.rs` (~366–371), file-info header:
+
+  ```rust
+  if let Some(tc) = entry.type_code_string() {
+      ui.label(format!("Type: {tc}"));
+  }
+  if let Some(cc) = entry.creator_code_string() {
+      ui.label(format!("Creator: {cc}"));
+  }
+  ```
+
+  Apply the same change to any other display spot (there's another around
+  ~687–689 in `browse_view.rs`).
+
+### 3. Extraction sites → use raw bytes, drop `fourcc`
+
+Everywhere a `[u8; 4]` is currently built via `fourcc(entry.type_code.as_deref())`
+or `entry.type_code.as_ref().map(|s| fourcc_bytes(s)).unwrap_or([0; 4])`, replace
+with the raw field directly (it's already `[u8; 4]`):
+
+```rust
+let type_code = entry.type_code.unwrap_or([0; 4]);
+let creator_code = entry.creator_code.unwrap_or([0; 4]);
+```
+
+then pass `&type_code` / `&creator_code` to `resource_fork::build_appledouble`
+and `resource_fork::build_macbinary` exactly as before (both already take
+`&[u8; 4]`). Sites to fix:
+
+- `src/cli/verbs/optical.rs` (~531–532 MacBinary, ~553–554 AppleDouble/etc.)
+- `src/optical/browse_view.rs` (~771–784 MacBinary, ~812–825 AppleDouble)
+
+### 4. Delete the now-dead helpers
+
+Once the extraction sites use raw bytes, these become unused — remove them (and
+fix any `dead_code` warning):
+
+- `fn fourcc(s: Option<&str>) -> [u8; 4]` in `src/cli/verbs/optical.rs` (~600)
+- `fn fourcc_bytes(s: &str) -> [u8; 4]` in `src/optical/browse_view.rs` (~877)
+
+Grep first to be sure nothing else calls them: `rg -n 'fourcc(_bytes)?\(' src`.
+(There are unrelated `fourcc_to_string` in `rbformats/chd.rs` and
+`fourcc_plausible` in `macarchive/macbinary.rs` — leave those alone.)
+
+### 5. Sweep for stragglers
+
+```sh
+rg -n 'type_code|creator_code|finder_flags' src
+```
+
+Fix any remaining `.as_deref()` / `{..}`-format / `&String` assumptions the same
+way, and update tests asserting the old `Option<String>` shape.
+
+## Optional follow-ups (only if clearly worthwhile)
+
+- Use `entry.finder_flags` to hide `isInvisible (0x4000)` files in the browse
+  view, or annotate aliases (`isAlias 0x8000`).
+
+## Verification (run all; report output)
+
+```sh
+cargo build --features optical
+cargo test  --features optical
+cargo clippy --features optical -- -D warnings
+cargo fmt --check
+cargo tree -i libchdman-rs        # expect a single version
+```
+
+If you have (or can make) a Mac HFS optical image with a file whose creator has a
+high-bit byte, extract it as AppleDouble and confirm the `._name` file now
+carries the correct 4 type/creator bytes (previously it'd be `b"0x.."`).
+
+## Done criteria
+
+- `Cargo.toml` → `opticaldiscs = "0.5"` (crates.io), or the path dep if 0.5.0
+  isn't published yet, with a note to flip it back.
+- All `type_code`/`creator_code` reads use raw bytes (extraction) or
+  `*_string()` (display); `fourcc` / `fourcc_bytes` deleted.
+- All five verification commands clean; the optical test suite passes.

--- a/docs/bump_opticaldiscs_0.6.md
+++ b/docs/bump_opticaldiscs_0.6.md
@@ -1,0 +1,158 @@
+# Bump `opticaldiscs` to 0.6.0 (file metadata + Joliet/Rock Ridge)
+
+> **Task prompt** for a Claude Code session working in this repo
+> (`rusty-backup`). Self-contained: follow it top to bottom, then run the
+> verification steps before reporting done. All line numbers are approximate —
+> `rg` for the symbols rather than trusting them. This work is gated behind the
+> `optical` feature, so build/test **with `--features optical`**.
+
+## Goal
+
+Bump the `opticaldiscs` dependency from **`0.5`** to **`0.6`**. The core bump is
+nearly free — 0.6.0's breaking change is *additive* (two new public fields on
+`FileEntry`), which does **not** break code that only *reads* `FileEntry` (which
+is all rusty-backup does). The value is new metadata the optical path can now
+carry through: **per-file dates**, **POSIX ownership/permissions**, and
+**Joliet / Rock Ridge** long-name + symlink support that now surfaces
+automatically in the optical browser.
+
+> rusty-backup currently pins `opticaldiscs = "0.5"` (`^0.5` = `<0.6.0`), so the
+> pin **must** be bumped or Cargo won't pick up 0.6.0.
+
+## Why bump
+
+1. **Correct Mac file dates on extraction (the headline win).** 0.6.0 exposes the
+   on-disc creation/modification timestamps via `FileEntry::timestamps`. For
+   HFS/HFS+ these are **raw seconds since the Mac epoch (1904-01-01)** — the
+   *exact* encoding MacBinary II uses — so they drop straight into the MacBinary
+   date fields with no conversion. Today rusty-backup writes no real dates.
+2. **Joliet + Rock Ridge (automatic).** The ISO 9660 browser now prefers a Joliet
+   tree (UTF-16BE Unicode names) when present, and reads Rock Ridge/SUSP for
+   POSIX metadata, long names, and symlink targets. The optical browse/extract UI
+   gets correct long/Unicode names and `symlink_target` for these discs with **no
+   code change**.
+3. **POSIX metadata** (`FileEntry::posix`: mode/uid/gid) is now available for
+   HFS+, EFS, and Rock Ridge discs — usable if/when extraction wants to preserve
+   permissions.
+
+## The (non-)breaking change
+
+`FileEntry` gained two public fields:
+
+```rust
+pub timestamps: Option<FileTimestamps>,   // raw, tagged by filesystem
+pub posix:      Option<PosixMetadata>,     // mode/uid/gid where available
+```
+
+Adding public fields to a non-`#[non_exhaustive]` struct is a *minor* semver
+break in Rust: it only breaks code that (a) builds `FileEntry` with a struct
+literal or (b) exhaustively destructures it with `FileEntry { .. }` **without**
+a trailing `..`. rusty-backup does neither (it consumes `FileEntry` from
+opticaldiscs' own browser), so **expect a clean compile with only the pin bump.**
+
+`MasterDirectoryBlock` and `HfsPlusVolumeHeader` also gained date fields (same
+additive rule). No function signatures changed; `new_hfs_file` is unchanged.
+
+New public API you may use (all re-exported at the crate root):
+
+```rust
+pub enum FileTimestamps {
+    Hfs     { created: u32, modified: u32, backup: u32 },                    // secs since 1904 (local)
+    HfsPlus { created: u32, content_modified: u32, attribute_modified: u32,
+              accessed: u32, backup: u32 },                                  // secs since 1904 (GMT)
+    Iso9660 { recorded: Iso9660DateTime, created: Option<Iso9660DateTime>,
+              modified: Option<Iso9660DateTime>, accessed: Option<Iso9660DateTime> },
+    Unix    { atime: i64, mtime: i64, ctime: i64 },                          // secs since 1970 (EFS)
+}
+pub struct PosixMetadata { pub mode: u32, pub uid: u32, pub gid: u32 }        // + permission_bits(), is_symlink()
+pub const MAC_EPOCH_UNIX_OFFSET: i64 = 2_082_844_800;                        // secs between 1904 and 1970 epochs
+// also: Iso9660DateTime (fields + year(), to_iso8601()), JolietVolumeDescriptor
+```
+
+## Required edits
+
+### 1. `Cargo.toml`
+
+```toml
+opticaldiscs = { version = "0.6", features = ["drives"], optional = true }
+```
+
+> If `opticaldiscs` 0.6.0 isn't on crates.io yet, point at the local checkout for
+> testing and flip back once published:
+>
+> ```toml
+> opticaldiscs = { path = "../opticaldiscs-rs", features = ["drives"], optional = true }
+> ```
+
+Then run `cargo tree -i libchdman-rs` and confirm opticaldiscs 0.6.0 (still on
+`libchdman-rs 0.288.8`, unchanged from 0.5.0) and rusty-backup's direct
+`libchdman-rs` dependency still resolve to a **single** copy.
+
+### 2. Confirm nothing broke (usually nothing)
+
+```sh
+rg -n 'FileEntry\s*\{|MasterDirectoryBlock\s*\{|HfsPlusVolumeHeader\s*\{' src
+```
+
+If any hit is a *construction* or an exhaustive destructure without `..`, add the
+new fields (or a trailing `, ..`). Expect **no hits** in rusty-backup's own code.
+
+## Optional follow-ups (do the dates one; it's the point of the bump)
+
+### A. Stamp real Mac dates into MacBinary / AppleDouble (recommended)
+
+The 0.5.0 bump wired extraction to use raw `type_code`/`creator_code`
+(`resource_fork::build_macbinary` / `build_appledouble`, called from
+`src/cli/verbs/optical.rs` and `src/optical/browse_view.rs`). Extend those to
+carry dates:
+
+- **MacBinary II** stores creation date at header offset 91 and modification date
+  at 95, both as **u32 secs since 1904** — i.e. exactly what
+  `FileTimestamps::Hfs`/`HfsPlus` already hold. Map directly:
+
+  ```rust
+  let (created, modified) = match entry.timestamps {
+      Some(FileTimestamps::Hfs { created, modified, .. }) => (created, modified),
+      Some(FileTimestamps::HfsPlus { created, content_modified, .. }) => (created, content_modified),
+      _ => (0, 0),
+  };
+  // pass created/modified (secs-since-1904) straight into the MacBinary date fields
+  ```
+
+- **AppleDouble** "File Dates Info" (entry ID 8) uses **secs since 2000-01-01**
+  (signed i32). Convert from the Mac-1904 value:
+  `let secs_2000 = (mac_1904 as i64) - MAC_EPOCH_UNIX_OFFSET - 946_684_800;`
+  (i.e. Mac-1904 → Unix → subtract the 2001 epoch offset), clamped to `i32`.
+
+  If `resource_fork::build_macbinary` / `build_appledouble` don't yet take date
+  args, add optional params (default to 0 / "now" when `timestamps` is `None`)
+  rather than changing every caller's behavior silently.
+
+### B. Symlinks / invisibles in the browser (optional)
+
+Rock Ridge/HFS symlinks now populate `entry.symlink_target`; `entry.posix`
+carries mode bits (`is_symlink()`, `permission_bits()`). Consider surfacing these
+in the browse view or skipping invisible entries.
+
+## Verification (run all; report output)
+
+```sh
+cargo build  --features optical
+cargo test   --features optical
+cargo clippy --features optical -- -D warnings
+cargo fmt --check
+cargo tree -i libchdman-rs        # expect a single 0.288.8
+```
+
+If you have a Mac HFS/HFS+ optical image, extract a file as MacBinary and confirm
+(with a hex dump or `macbinary`-aware tool) that the creation/modification dates
+now match the on-disc dates instead of being zero. For a Joliet or Rock Ridge ISO,
+confirm long/Unicode names and any symlinks appear in the browse listing.
+
+## Done criteria
+
+- `Cargo.toml` → `opticaldiscs = "0.6"` (crates.io), or the path dep if 0.6.0
+  isn't published yet, with a note to flip it back.
+- Clean compile (no `FileEntry` literal/exhaustive-match breakage).
+- All five verification commands clean; the optical test suite passes.
+- (If done) MacBinary/AppleDouble extraction carries real Mac dates.

--- a/examples/repro_shork.rs
+++ b/examples/repro_shork.rs
@@ -1,0 +1,88 @@
+//! Throwaway repro: mirror the GUI inspect-tab worker analysis on a disk
+//! image, including the expensive ext minimum-size walk that the "Calc min"
+//! button triggers. Run in debug (overflow checks on) to surface the panic.
+//!
+//!   cargo run --example repro_shork -- /Users/dani/Downloads/shork-486.vhd
+
+use std::io::BufReader;
+
+use rusty_backup::fs;
+use rusty_backup::partition::{detect_alignment, PartitionTable};
+
+fn main() {
+    let path = std::env::args().nth(1).expect("usage: repro_shork <image>");
+    println!("opening {path}");
+
+    // Mirror the GUI inspect worker's open path for non-container files:
+    // detect_image_format_with_path + wrap_image_reader (NOT open_read).
+    println!("== detect_image_format_with_path (GUI path) ==");
+    let f = std::fs::File::open(&path).unwrap();
+    let format = rusty_backup::rbformats::detect_image_format_with_path(
+        f,
+        Some(std::path::Path::new(&path)),
+    )
+    .expect("detect_image_format");
+    println!("  format = {}", format.description());
+
+    println!("== wrap_image_reader ==");
+    let f2 = std::fs::File::open(&path).unwrap();
+    let (mut reader, data_size) =
+        rusty_backup::rbformats::wrap_image_reader(f2, format).expect("wrap_image_reader");
+    println!("  wrapped data_size = {data_size}");
+
+    println!("== PartitionTable::detect ==");
+    let table = PartitionTable::detect(&mut reader).expect("detect");
+    println!("table ok");
+    let _ = BufReader::new(std::fs::File::open(&path).unwrap()); // keep import
+
+    println!("== detect_alignment ==");
+    let alignment = detect_alignment(&table);
+    println!("alignment = {:?}", alignment.alignment_type);
+
+    let partitions = table.partitions();
+    for part in &partitions {
+        println!(
+            "== partition {} type=0x{:02X} offset={} size={} ==",
+            part.index,
+            part.partition_type_byte,
+            part.byte_offset(),
+            part.size_bytes
+        );
+
+        println!("  probe_0x83_fs_type:");
+        let mut r = rusty_backup::model::source_reader::open_read(std::path::Path::new(&path))
+            .expect("reopen");
+        let fam = fs::probe_0x83_fs_type(&mut r, part.byte_offset());
+        println!("    -> {fam:?}");
+
+        for (label, expensive) in [("deferred(false)", false), ("calc-min(true)", true)] {
+            println!("  partition_minimum_size {label}:");
+            let r = rusty_backup::model::source_reader::open_read(std::path::Path::new(&path))
+                .expect("reopen");
+            let res = fs::partition_minimum_size(
+                r,
+                part.byte_offset(),
+                part.partition_type_byte,
+                part.partition_type_string.as_deref(),
+                part.size_bytes,
+                expensive,
+                None,
+                &|m| println!("      [progress] {m}"),
+            );
+            match res {
+                fs::MinimumResult::Computed {
+                    in_place,
+                    defragmented,
+                    fragmentation_percent,
+                } => println!(
+                    "    -> Computed in_place={in_place:?} defrag={defragmented:?} frag={fragmentation_percent:?}"
+                ),
+                fs::MinimumResult::Deferred { fs_name } => {
+                    println!("    -> Deferred({fs_name})")
+                }
+            }
+        }
+    }
+
+    println!("ALL DONE (no panic)");
+}

--- a/src/fs/fork_export.rs
+++ b/src/fs/fork_export.rs
@@ -1,0 +1,140 @@
+//! Fork-preserving single-file export, shared by the browse view's "Extract"
+//! and Commander's copy/export-to-host.
+//!
+//! Reads a file's data fork (`read_file`) and resource fork
+//! (`write_resource_fork_to`) off any [`Filesystem`] and writes it into a host
+//! directory in the chosen [`ResourceForkMode`]:
+//! - **MacBinary** — single `.bin` carrying both forks (only when a resource
+//!   fork is present; otherwise falls through to a plain data-fork write).
+//! - **BinHex** — single `.hqx` text file (always applicable; carries Finder
+//!   info even with no resource fork).
+//! - **AppleDouble** — data fork under the plain name + a `._name` sidecar
+//!   (emitted whenever there's a resource fork *or* type/creator to preserve).
+//! - **Native** — data fork + the macOS `..namedfork/rsrc` write (macOS only).
+//! - **SeparateRsrc** — data fork + a `name.rsrc` sidecar.
+//! - **DataForkOnly** — just the data fork.
+//!
+//! This mirrors the browse view's `extract_entry` per-file logic in one place
+//! so Commander gets identical output, and it works over the remote wire too
+//! (`RemoteFilesystem` implements `write_resource_fork_to` via the daemon's
+//! resource-fork read op).
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::fs::binhex;
+use crate::fs::entry::FileEntry;
+use crate::fs::filesystem::Filesystem;
+use crate::fs::resource_fork::{self, MacFileDates, ResourceForkMode};
+
+/// The default sanitized host filename for `entry` (no ProDOS type suffix).
+/// Callers with no special naming needs pass this as `out_name`.
+pub fn safe_name(entry: &FileEntry) -> String {
+    resource_fork::sanitize_filename(&entry.name)
+}
+
+/// Export one FILE `entry` into `dest_dir` under the base name `out_name`
+/// (already sanitized / suffixed by the caller — e.g. the browse view appends a
+/// ProDOS `#TTAAAA` suffix), using `mode`. Returns the number of bytes written
+/// (data + resource) for progress accounting. The caller handles directories
+/// (create + recurse). Use [`safe_name`] for the default sanitized name.
+pub fn export_file_with_fork(
+    fs: &mut dyn Filesystem,
+    entry: &FileEntry,
+    dest_dir: &Path,
+    out_name: &str,
+    mode: ResourceForkMode,
+) -> Result<u64> {
+    let safe = out_name;
+    let has_rsrc = entry.resource_fork_size.map(|s| s > 0).unwrap_or(false);
+    let type_code = entry.type_code.unwrap_or([0; 4]);
+    let creator_code = entry.creator_code.unwrap_or([0; 4]);
+    // HFS/HFS+ catalog dates are already raw Mac-1904 seconds — the exact
+    // MacBinary / AppleDouble encoding — so carry them straight through.
+    let dates = entry
+        .mac_dates
+        .map(|(created, modified, _backup)| MacFileDates { created, modified })
+        .unwrap_or_default();
+
+    let read_data = |fs: &mut dyn Filesystem| -> Result<Vec<u8>> {
+        fs.read_file(entry, usize::MAX)
+            .with_context(|| format!("reading '{}'", entry.name))
+    };
+    let read_rsrc = |fs: &mut dyn Filesystem| -> Result<Vec<u8>> {
+        let mut buf = Vec::new();
+        fs.write_resource_fork_to(entry, &mut buf)
+            .with_context(|| format!("reading resource fork of '{}'", entry.name))?;
+        Ok(buf)
+    };
+
+    if mode == ResourceForkMode::MacBinary && has_rsrc {
+        let data = read_data(fs)?;
+        let rsrc = read_rsrc(fs)?;
+        let mb =
+            resource_fork::build_macbinary(safe, &type_code, &creator_code, dates, &data, &rsrc);
+        let out = dest_dir.join(format!("{safe}.bin"));
+        std::fs::write(&out, &mb).with_context(|| format!("writing {}", out.display()))?;
+        return Ok(data.len() as u64 + rsrc.len() as u64);
+    }
+
+    if mode == ResourceForkMode::BinHex {
+        let data = read_data(fs)?;
+        let rsrc = if has_rsrc { read_rsrc(fs)? } else { Vec::new() };
+        let bh = binhex::BinHexFile {
+            name: entry.name.clone(),
+            type_code,
+            creator_code,
+            flags: 0,
+            data_fork: data,
+            resource_fork: rsrc,
+        };
+        let text = binhex::build_binhex(&bh);
+        let out = dest_dir.join(format!("{safe}.hqx"));
+        std::fs::write(&out, text.as_bytes())
+            .with_context(|| format!("writing {}", out.display()))?;
+        return Ok(bh.data_fork.len() as u64 + bh.resource_fork.len() as u64);
+    }
+
+    // Data fork to the plain name...
+    let out = dest_dir.join(safe);
+    let mut f =
+        std::fs::File::create(&out).with_context(|| format!("creating {}", out.display()))?;
+    let written = fs
+        .write_file_to(entry, &mut f)
+        .with_context(|| format!("extracting '{}'", entry.name))?;
+    drop(f);
+
+    // ...plus a resource-fork sidecar for the fork-carrying "beside the data
+    // fork" modes. MacBinary-without-rsrc and DataForkOnly land here as a plain
+    // data-fork write with no sidecar.
+    let mut extra = 0u64;
+    let has_finfo = type_code != [0; 4] || creator_code != [0; 4];
+    match mode {
+        ResourceForkMode::Native if has_rsrc => {
+            let rsrc = read_rsrc(fs)?;
+            let p = out.join("..namedfork/rsrc");
+            std::fs::write(&p, &rsrc)
+                .with_context(|| format!("writing native resource fork of '{}'", entry.name))?;
+            extra = rsrc.len() as u64;
+        }
+        ResourceForkMode::AppleDouble if has_rsrc || has_finfo => {
+            let rsrc = if has_rsrc { read_rsrc(fs)? } else { Vec::new() };
+            let ad = resource_fork::build_appledouble(&type_code, &creator_code, dates, &rsrc);
+            let p = dest_dir.join(format!("._{safe}"));
+            std::fs::write(&p, &ad)
+                .with_context(|| format!("writing AppleDouble sidecar of '{}'", entry.name))?;
+            extra = rsrc.len() as u64;
+        }
+        ResourceForkMode::SeparateRsrc if has_rsrc => {
+            let rsrc = read_rsrc(fs)?;
+            let p = dest_dir.join(format!("{safe}.rsrc"));
+            std::fs::write(&p, &rsrc)
+                .with_context(|| format!("writing .rsrc sidecar of '{}'", entry.name))?;
+            extra = rsrc.len() as u64;
+        }
+        _ => {}
+    }
+
+    Ok(written + extra)
+}

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -25,6 +25,7 @@ pub mod exfat_clone;
 pub mod ext;
 pub mod fat;
 pub mod filesystem;
+pub mod fork_export;
 pub mod fsck;
 pub mod hfs;
 pub mod hfs_boot;

--- a/src/gui/archives_tab.rs
+++ b/src/gui/archives_tab.rs
@@ -72,6 +72,9 @@ struct ExtractStatus {
 }
 
 pub struct ArchivesTab {
+    /// MRU of opened archive paths (newest first), mirrored to `config.json` —
+    /// the "Recent:" quick-pick row.
+    recent_files: Vec<String>,
     archive_path: Option<PathBuf>,
     prev_path: Option<PathBuf>,
     loaded: Option<Loaded>,
@@ -87,6 +90,7 @@ pub struct ArchivesTab {
 impl Default for ArchivesTab {
     fn default() -> Self {
         Self {
+            recent_files: super::load_recent(rusty_backup::update::RecentMode::Archives),
             archive_path: None,
             prev_path: None,
             loaded: None,
@@ -135,7 +139,23 @@ impl ArchivesTab {
     /// change). Used when the Inspect tab redirects a picked Mac-archive file
     /// here instead of trying to parse it as a disk image.
     pub fn open_path(&mut self, path: PathBuf) {
+        self.recent_files = super::push_recent(rusty_backup::update::RecentMode::Archives, &path);
         self.archive_path = Some(path);
+    }
+
+    /// Drop this tab's in-memory recent-files mirror (the Settings dialog clears
+    /// the persisted lists; the mirror otherwise only reloads at construction).
+    pub(crate) fn clear_recent_files(&mut self) {
+        self.recent_files.clear();
+    }
+
+    /// Unload the current archive (the "Close" button). Leaves the recent list
+    /// intact so the user can re-open.
+    pub fn close(&mut self) {
+        self.archive_path = None;
+        self.prev_path = None;
+        self.loaded = None;
+        self.load_error = None;
     }
 
     /// Spawn the background extractor. When `selected_only` is true,
@@ -279,8 +299,19 @@ impl ArchivesTab {
                     .add_filter("All Files", &["*"])
                     .pick_file()
                 {
-                    self.archive_path = Some(path);
+                    self.open_path(path);
                 }
+            }
+            if self.archive_path.is_some()
+                && ui
+                    .add_enabled(!running, egui::Button::new("Close"))
+                    .on_hover_text("Unload the current archive")
+                    .clicked()
+            {
+                self.close();
+            }
+            if let Some(path) = super::recent_combo(ui, "archives_recent", &self.recent_files, 0) {
+                self.open_path(path);
             }
         });
 

--- a/src/gui/backup_tab.rs
+++ b/src/gui/backup_tab.rs
@@ -26,6 +26,10 @@ use super::progress::ProgressState;
 
 /// State for the Backup tab.
 pub struct BackupTab {
+    /// In-memory mirror of the Backup mode's recent-image MRU (config.json),
+    /// seeded at construction and refreshed on each image open; drives the
+    /// "Recent..." quick-pick beside the source dropdown.
+    recent_files: Vec<String>,
     selected_device_idx: Option<usize>,
     image_file_path: Option<PathBuf>,
     /// Holds the decompressed `.adz` / `.hdz` payload alive for the
@@ -177,6 +181,7 @@ impl VhdPartitionConfig {
 impl Default for BackupTab {
     fn default() -> Self {
         Self {
+            recent_files: super::load_recent(rusty_backup::update::RecentMode::Backup),
             selected_device_idx: None,
             image_file_path: None,
             amiga_tempdir: None,
@@ -330,6 +335,10 @@ impl BackupTab {
                                 .pick_file()
                             {
                                 self.selected_device_idx = None;
+                                self.recent_files = super::push_recent(
+                                    rusty_backup::update::RecentMode::Backup,
+                                    &path,
+                                );
                                 // Backup decodes floppy containers to a flat
                                 // image (true): it needs a raw sector stream to
                                 // compress.
@@ -368,6 +377,11 @@ impl BackupTab {
                             }
                         }
                     });
+                if let Some(path) = super::recent_combo(ui, "backup_recent", &self.recent_files, 5)
+                {
+                    self.open_image(path);
+                    self.update_backup_name(ctx);
+                }
             });
             #[cfg(feature = "remote")]
             if self.remote_active()
@@ -2043,6 +2057,34 @@ impl BackupTab {
     /// clear every piece of derived partition state. Mirrors the per-source
     /// reset in `load_partition_preview` plus the selection itself, returning
     /// the tab to its "Select a device or image..." state.
+    /// Open `path` as the image-file backup source (drag-and-drop router).
+    /// Mirrors the "Open Image File..." picker: floppy containers are decoded to
+    /// a flat image (Backup needs a raw sector stream to compress). `show()`
+    /// loads the partition preview on the next frame via the
+    /// `image_file_path != prev_image_path` check, and drops any active remote
+    /// source so the two don't fight.
+    pub fn open_image(&mut self, path: PathBuf) {
+        self.selected_device_idx = None;
+        self.recent_files = super::push_recent(rusty_backup::update::RecentMode::Backup, &path);
+        match super::prepare_disk_image_path(&path, true) {
+            Ok((materialized, guard)) => {
+                self.image_file_path = Some(materialized);
+                self.amiga_tempdir = guard;
+            }
+            Err(e) => {
+                log::error!("Failed to decompress {}: {}", path.display(), e);
+                self.image_file_path = Some(path);
+                self.amiga_tempdir = None;
+            }
+        }
+    }
+
+    /// Drop this tab's in-memory recent-files mirror (the Settings dialog clears
+    /// the persisted lists; the mirror otherwise only reloads at construction).
+    pub(crate) fn clear_recent_files(&mut self) {
+        self.recent_files.clear();
+    }
+
     fn close_source(&mut self) {
         self.selected_device_idx = None;
         self.image_file_path = None;

--- a/src/gui/browse_view.rs
+++ b/src/gui/browse_view.rs
@@ -4,13 +4,13 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use rusty_backup::clonezilla::block_cache::PartcloneBlockCache;
 use rusty_backup::fs::entry::{EntryType, FileEntry};
 use rusty_backup::fs::filesystem::Filesystem;
+use rusty_backup::fs::fork_export;
 use rusty_backup::fs::resource_fork::{self, ResourceForkMode};
 use rusty_backup::fs::zstd_stream::ZstdStreamCache;
 use rusty_backup::macarchive::detect::{detect_mac_archive, MacArchiveKind};
@@ -1958,7 +1958,6 @@ impl BrowseView {
     fn launch_extraction(&mut self, entry: FileEntry, dest: PathBuf) {
         let session = self.session.clone();
         let resource_fork_mode = self.resource_fork_mode;
-        let is_hfs = self.is_hfs_type();
         let is_prodos = self.is_prodos_type();
         let prodos_export_mode = self.prodos_export_mode;
 
@@ -1984,7 +1983,6 @@ impl BrowseView {
                 &entry,
                 &dest,
                 resource_fork_mode,
-                is_hfs,
                 is_prodos,
                 prodos_export_mode,
                 &progress,
@@ -5277,7 +5275,6 @@ fn run_extraction(
     entry: &FileEntry,
     dest: &std::path::Path,
     resource_fork_mode: ResourceForkMode,
-    is_hfs: bool,
     is_prodos: bool,
     prodos_export_mode: ProdosExportMode,
     progress: &Arc<Mutex<ExtractionProgress>>,
@@ -5300,7 +5297,6 @@ fn run_extraction(
         entry,
         dest,
         resource_fork_mode,
-        is_hfs,
         is_prodos,
         prodos_export_mode,
         progress,
@@ -5348,7 +5344,6 @@ fn extract_entry(
     entry: &FileEntry,
     dest: &std::path::Path,
     resource_fork_mode: ResourceForkMode,
-    is_hfs: bool,
     is_prodos: bool,
     prodos_export_mode: ProdosExportMode,
     progress: &Arc<Mutex<ExtractionProgress>>,
@@ -5383,151 +5378,18 @@ fn extract_entry(
                 p.current_file = entry.path.clone();
             }
 
-            let has_rsrc = is_hfs && entry.resource_fork_size.map(|s| s > 0).unwrap_or(false);
-
-            if has_rsrc && resource_fork_mode == ResourceForkMode::MacBinary {
-                // MacBinary: single .bin file containing both forks
-                let data = fs.read_file(entry, usize::MAX)?;
-                let mut rsrc_buf = Vec::new();
-                fs.write_resource_fork_to(entry, &mut rsrc_buf)?;
-
-                let type_code = entry.type_code.unwrap_or([0; 4]);
-                let creator_code = entry.creator_code.unwrap_or([0; 4]);
-                // HFS/HFS+ catalog dates are raw Mac-1904 seconds — the exact
-                // MacBinary encoding — so carry them straight through.
-                let dates = entry
-                    .mac_dates
-                    .map(|(created, modified, _backup)| resource_fork::MacFileDates {
-                        created,
-                        modified,
-                    })
-                    .unwrap_or_default();
-
-                let mb = resource_fork::build_macbinary(
-                    &safe_name,
-                    &type_code,
-                    &creator_code,
-                    dates,
-                    &data,
-                    &rsrc_buf,
-                );
-                let out_path = dest.join(format!("{safe_name}.bin"));
-                let mut f = BufWriter::new(File::create(&out_path)?);
-                f.write_all(&mb)?;
-                f.flush()?;
-
-                if let Ok(mut p) = progress.lock() {
-                    p.current_bytes += data.len() as u64 + rsrc_buf.len() as u64;
-                    p.files_extracted += 1;
-                }
-            } else if resource_fork_mode == ResourceForkMode::BinHex {
-                // BinHex: single .hqx text file with both forks + Finder info.
-                // Always applicable to a file, even with no resource fork.
-                let data = fs.read_file(entry, usize::MAX)?;
-                let mut rsrc_buf = Vec::new();
-                if has_rsrc {
-                    fs.write_resource_fork_to(entry, &mut rsrc_buf)?;
-                }
-
-                let type_code = entry.type_code.unwrap_or([0; 4]);
-                let creator_code = entry.creator_code.unwrap_or([0; 4]);
-
-                let bh = rusty_backup::fs::binhex::BinHexFile {
-                    // Preserve the original Mac name inside the archive.
-                    name: entry.name.clone(),
-                    type_code,
-                    creator_code,
-                    flags: 0,
-                    data_fork: data,
-                    resource_fork: rsrc_buf,
-                };
-                let text = rusty_backup::fs::binhex::build_binhex(&bh);
-                let out_path = dest.join(format!("{safe_name}.hqx"));
-                let mut f = BufWriter::new(File::create(&out_path)?);
-                f.write_all(text.as_bytes())?;
-                f.flush()?;
-
-                if let Ok(mut p) = progress.lock() {
-                    p.current_bytes += bh.data_fork.len() as u64 + bh.resource_fork.len() as u64;
-                    p.files_extracted += 1;
-                }
-            } else {
-                // Write data fork
-                let out_path = dest.join(&safe_name);
-                let mut f = BufWriter::new(File::create(&out_path)?);
-                let written = fs.write_file_to(entry, &mut f)?;
-                f.flush()?;
-
-                if let Ok(mut p) = progress.lock() {
-                    p.current_bytes += written;
-                }
-
-                if is_hfs && resource_fork_mode != ResourceForkMode::DataForkOnly {
-                    let type_code = entry.type_code.unwrap_or([0; 4]);
-                    let creator_code = entry.creator_code.unwrap_or([0; 4]);
-                    let has_finfo = type_code != [0; 4] || creator_code != [0; 4];
-                    // HFS/HFS+ catalog dates are raw Mac-1904 seconds; carry them
-                    // into the AppleDouble File Dates Info entry when present.
-                    let dates = entry
-                        .mac_dates
-                        .map(|(created, modified, _backup)| resource_fork::MacFileDates {
-                            created,
-                            modified,
-                        })
-                        .unwrap_or_default();
-
-                    let mut rsrc_buf = Vec::new();
-                    if has_rsrc {
-                        fs.write_resource_fork_to(entry, &mut rsrc_buf)?;
-                    }
-
-                    if has_rsrc || has_finfo {
-                        // Per-mode `has_rsrc` gates are explicit on purpose:
-                        // the Native + SeparateRsrc paths only emit when a
-                        // resource fork is present, while AppleDouble always
-                        // emits (it carries Finder Info too).
-                        #[allow(clippy::collapsible_match)]
-                        match resource_fork_mode {
-                            ResourceForkMode::Native => {
-                                if has_rsrc {
-                                    let rsrc_path = out_path.join("..namedfork/rsrc");
-                                    let mut rf = BufWriter::new(File::create(&rsrc_path)?);
-                                    rf.write_all(&rsrc_buf)?;
-                                    rf.flush()?;
-                                }
-                            }
-                            ResourceForkMode::AppleDouble => {
-                                let ad = resource_fork::build_appledouble(
-                                    &type_code,
-                                    &creator_code,
-                                    dates,
-                                    &rsrc_buf,
-                                );
-                                let ad_path = dest.join(format!("._{safe_name}"));
-                                let mut af = BufWriter::new(File::create(&ad_path)?);
-                                af.write_all(&ad)?;
-                                af.flush()?;
-                            }
-                            ResourceForkMode::SeparateRsrc => {
-                                if has_rsrc {
-                                    let rsrc_path = dest.join(format!("{safe_name}.rsrc"));
-                                    let mut rf = BufWriter::new(File::create(&rsrc_path)?);
-                                    rf.write_all(&rsrc_buf)?;
-                                    rf.flush()?;
-                                }
-                            }
-                            _ => {}
-                        }
-
-                        if let Ok(mut p) = progress.lock() {
-                            p.current_bytes += rsrc_buf.len() as u64;
-                        }
-                    }
-                }
-
-                if let Ok(mut p) = progress.lock() {
-                    p.files_extracted += 1;
-                }
+            // All fork formats (MacBinary / BinHex / AppleDouble / Native /
+            // SeparateRsrc / DataForkOnly) go through the shared per-file
+            // exporter so the browse view and Commander produce identical output.
+            // `safe_name` carries any ProDOS `#TTAAAA` suffix computed above.
+            let written =
+                fork_export::export_file_with_fork(fs, entry, dest, &safe_name, resource_fork_mode)
+                    .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
+                        format!("{e:#}").into()
+                    })?;
+            if let Ok(mut p) = progress.lock() {
+                p.current_bytes += written;
+                p.files_extracted += 1;
             }
         }
         EntryType::Directory => {
@@ -5541,7 +5403,6 @@ fn extract_entry(
                     child,
                     &dir_path,
                     resource_fork_mode,
-                    is_hfs,
                     is_prodos,
                     prodos_export_mode,
                     progress,

--- a/src/gui/commander/mod.rs
+++ b/src/gui/commander/mod.rs
@@ -22,6 +22,8 @@ use std::sync::{Arc, Mutex};
 use eframe::egui;
 
 use rusty_backup::fs::entry::FileEntry;
+use rusty_backup::fs::fork_export::{export_file_with_fork, safe_name};
+use rusty_backup::fs::resource_fork::ResourceForkMode;
 use rusty_backup::model::checksum::{self, ChecksumJob, ChecksumStatus};
 use rusty_backup::model::commander_ops::{self, HostCopyJob, HostCopyStatus};
 use rusty_backup::partition::format_size;
@@ -126,6 +128,10 @@ pub struct CommanderMode {
     /// timestamps on the destination (HFS catalog dates / Amiga datestamp)
     /// instead of stamping the current time. Defaults on.
     keep_dates: bool,
+    /// How resource forks are preserved when copying/exporting an image file to
+    /// a host folder (MacBinary / BinHex / AppleDouble / … via
+    /// [`export_file_with_fork`]). Ignored for host->host copies.
+    export_fork_mode: ResourceForkMode,
     /// The pane the user last interacted with — the middle-column Delete acts
     /// on it. Updated from each pane's `focused` response.
     active: Side,
@@ -158,10 +164,31 @@ impl CommanderMode {
             checksums: None,
             detail: None,
             keep_dates: true,
+            export_fork_mode: ResourceForkMode::MacBinary,
             active: Side::Left,
             session_log: Vec::new(),
             show_log: false,
         }
+    }
+
+    /// Open a drag-and-dropped path in the active pane (the drag-and-drop router
+    /// in `RustyBackupApp::update` calls this while the Commander overlay is up).
+    /// A directory opens as a host folder, a file as an image source.
+    pub fn open_dropped_path(&mut self, path: PathBuf) {
+        let msg = match self.active {
+            Side::Left => self.left.open_dropped(path),
+            Side::Right => self.right.open_dropped(path),
+        };
+        if !msg.is_empty() {
+            self.status = msg;
+        }
+    }
+
+    /// Drop both panes' in-memory recent-files mirrors (the Settings dialog
+    /// cleared the persisted lists).
+    pub(crate) fn clear_recent_files(&mut self) {
+        self.left.clear_recent_files();
+        self.right.clear_recent_files();
     }
 
     /// Upper bound on retained session-log entries (rolling; oldest drop first).
@@ -221,11 +248,13 @@ impl CommanderMode {
         egui::CentralPanel::default().show_inside(ui, |ui| {
             let full_h = ui.available_height();
             let full_w = ui.available_width();
-            let mid_w = 132.0;
+            // Wide enough for the middle column's widest control (the "Export
+            // forks as:" combo) without overflowing into the panes.
+            let mid_w = 168.0;
             // Reserve room for the two separators + the item spacing between the
             // five horizontal items, so the right pane isn't clipped off-edge.
             let gaps = ui.spacing().item_spacing.x * 4.0 + 16.0;
-            let pane_w = ((full_w - mid_w - gaps) / 2.0).max(180.0);
+            let pane_w = ((full_w - mid_w - gaps) / 2.0).max(220.0);
             ui.horizontal_top(|ui| {
                 ui.allocate_ui_with_layout(
                     egui::vec2(pane_w, full_h),
@@ -344,41 +373,58 @@ impl CommanderMode {
         let l_can = idle && self.left.has_selection() && self.right.can_receive();
         let r_can = idle && self.right.has_selection() && self.left.can_receive();
 
+        // Copy into a remote *host* folder isn't supported yet (only remote disk
+        // images) — surface that in the hover so the greyed button reads as
+        // "not yet" rather than "broken".
+        const REMOTE_HOST_HINT: &str =
+            "Copying into a remote host folder isn't supported yet — only remote disk images";
+        let l_copy_hover = if self.right.is_remote_host_dest() {
+            REMOTE_HOST_HINT
+        } else {
+            "Copy the left pane's selection into the right pane"
+        };
+        let r_copy_hover = if self.left.is_remote_host_dest() {
+            REMOTE_HOST_HINT
+        } else {
+            "Copy the right pane's selection into the left pane"
+        };
+
         // Pictured buttons (procedurally painted — no font glyphs, no assets):
         // stacked floppies + arrow for copy, a floppy with a red X for delete,
         // and "101=011?" for the (disabled) compare.
-        if icon_button(
-            ui,
-            sz,
-            l_can,
-            "Copy the left pane's selection into the right pane",
-            |p, r, c| draw_copy_icon(p, r, c, true),
-        )
+        if icon_button(ui, sz, l_can, l_copy_hover, |p, r, c| {
+            draw_copy_icon(p, r, c, true)
+        })
         .clicked()
         {
             status = Some(self.copy(Side::Left));
         }
         ui.add_space(6.0);
-        if icon_button(
-            ui,
-            sz,
-            r_can,
-            "Copy the right pane's selection into the left pane",
-            |p, r, c| draw_copy_icon(p, r, c, false),
-        )
+        if icon_button(ui, sz, r_can, r_copy_hover, |p, r, c| {
+            draw_copy_icon(p, r, c, false)
+        })
         .clicked()
         {
             status = Some(self.copy(Side::Right));
         }
         ui.add_space(12.0);
-        // Delete acts on the active pane (the one last clicked in). Disabled
-        // when that pane is a read-only backup.
+        // Delete acts on the active pane (the one last clicked in). Disabled when
+        // that pane is read-only (backup or archive) or a remote image (the
+        // remote write path carries copies only for now, not deletes).
         let active = self.active;
-        let (active_has_sel, active_backup) = match active {
-            Side::Left => (self.left.has_selection(), self.left.is_backup_pane()),
-            Side::Right => (self.right.has_selection(), self.right.is_backup_pane()),
+        let (active_has_sel, active_readonly, active_remote) = match active {
+            Side::Left => (
+                self.left.has_selection(),
+                self.left.is_backup_pane() || self.left.is_archive_pane(),
+                self.left.is_remote(),
+            ),
+            Side::Right => (
+                self.right.has_selection(),
+                self.right.is_backup_pane() || self.right.is_archive_pane(),
+                self.right.is_remote(),
+            ),
         };
-        let del_enabled = idle && active_has_sel && !active_backup;
+        let del_enabled = idle && active_has_sel && !active_readonly && !active_remote;
         let del_hover = format!("Delete the selected item(s) in the {} pane", active.label());
         if icon_button(ui, sz, del_enabled, &del_hover, draw_delete_icon).clicked() {
             status = Some(match active {
@@ -401,6 +447,25 @@ impl CommanderMode {
                  destination (HFS catalog dates / Amiga datestamp) instead of \
                  stamping the current time. Image-to-image copies only.",
             );
+        ui.add_space(8.0);
+        // Resource-fork format for image->host copies / exports. When copying a
+        // Mac file out to a host folder, its resource fork is preserved in the
+        // chosen container (MacBinary / BinHex / AppleDouble / …).
+        ui.label("Export forks as:");
+        egui::ComboBox::from_id_salt("commander_fork_mode")
+            .selected_text(self.export_fork_mode.label())
+            .width(150.0)
+            .show_ui(ui, |ui| {
+                for mode in ResourceForkMode::ALL {
+                    ui.selectable_value(&mut self.export_fork_mode, mode, mode.label());
+                }
+            })
+            .response
+            .on_hover_text(
+                "How to preserve a Mac file's resource fork when copying it out to \
+                 a host folder (image->host copies and Export). Host->host copies \
+                 keep bytes as-is.",
+            );
         status
     }
 
@@ -411,6 +476,7 @@ impl CommanderMode {
     /// - image -> host / host -> host: an immediate threaded host write.
     fn copy(&mut self, from: Side) -> String {
         let keep_dates = self.keep_dates;
+        let fork_mode = self.export_fork_mode;
         let (src, dest) = match from {
             Side::Left => (&mut self.left, &mut self.right),
             Side::Right => (&mut self.right, &mut self.left),
@@ -476,7 +542,7 @@ impl CommanderMode {
                     let Some(src_fs) = src.fs_mut() else {
                         return "Source volume is not open.".to_string();
                     };
-                    return match extract_entries_to_host(src_fs, &entries, &dest_dir) {
+                    return match extract_entries_to_host(src_fs, &entries, &dest_dir, fork_mode) {
                         Ok(n) => {
                             dest.reload_listing();
                             format!("Copied {n} item(s) to the {other} folder.")
@@ -491,6 +557,7 @@ impl CommanderMode {
                     session,
                     entries,
                     dest_dir,
+                    fork_mode,
                 };
                 self.pending_host_copy =
                     Some((Some(from.other()), commander_ops::spawn_host_copy(job)));
@@ -516,9 +583,10 @@ impl CommanderMode {
         if self.pending_host_copy.is_some() {
             return "A copy is already in progress; wait for it to finish.".to_string();
         }
+        let fork_mode = self.export_fork_mode;
         let src = match from {
-            Side::Left => &self.left,
-            Side::Right => &self.right,
+            Side::Left => &mut self.left,
+            Side::Right => &mut self.right,
         };
         let entries = src.selected_entries();
         if entries.is_empty() {
@@ -528,17 +596,33 @@ impl CommanderMode {
             return "Export cancelled.".to_string();
         };
 
-        let job = if src.is_host_pane() {
-            HostCopyJob::HostToHost { entries, dest_dir }
-        } else {
-            let Some(session) = src.session() else {
+        if src.is_host_pane() {
+            let job = HostCopyJob::HostToHost { entries, dest_dir };
+            self.pending_host_copy = Some((None, commander_ops::spawn_host_copy(job)));
+            return format!(
+                "Exporting the {} pane selection to the host folder...",
+                from.label()
+            );
+        }
+        // A remote image pane has no local BrowseSession, so extract over the
+        // wire synchronously (same path the cross-pane remote copy uses).
+        if src.session().is_none() {
+            let Some(src_fs) = src.fs_mut() else {
                 return "Source volume is not open.".to_string();
             };
-            HostCopyJob::ImageToHost {
-                session,
-                entries,
-                dest_dir,
-            }
+            return match extract_entries_to_host(src_fs, &entries, &dest_dir, fork_mode) {
+                Ok(n) => format!("Exported {n} item(s) to {}.", dest_dir.display()),
+                Err(e) => format!("Export failed: {e}"),
+            };
+        }
+        let Some(session) = src.session() else {
+            return "Source volume is not open.".to_string();
+        };
+        let job = HostCopyJob::ImageToHost {
+            session,
+            entries,
+            dest_dir,
+            fork_mode,
         };
         self.pending_host_copy = Some((None, commander_ops::spawn_host_copy(job)));
         format!(
@@ -727,8 +811,8 @@ impl CommanderMode {
             Side::Right => &mut self.right,
         };
         // A writable image volume gets the metadata editors; host folders and
-        // read-only backups show the metadata without them.
-        let editable = !pane.is_host_pane() && !pane.is_backup_pane();
+        // read-only backups / archives show the metadata without them.
+        let editable = !pane.is_host_pane() && !pane.is_backup_pane() && !pane.is_archive_pane();
         let fs_type = pane.fs_type().to_string();
         let Some((entry, bytes)) = pane.detail_payload(&name, MAX_PREVIEW_SIZE) else {
             return format!("[{}] could not open File Info for '{name}'.", from.label());
@@ -939,21 +1023,20 @@ fn extract_entries_to_host(
     src_fs: &mut dyn rusty_backup::fs::filesystem::Filesystem,
     entries: &[FileEntry],
     dest_dir: &std::path::Path,
+    fork_mode: ResourceForkMode,
 ) -> std::io::Result<usize> {
     let mut count = 0;
     for e in entries {
-        let target = dest_dir.join(&e.name);
         if e.is_directory() {
+            let target = dest_dir.join(&e.name);
             std::fs::create_dir_all(&target)?;
             let children = src_fs
                 .list_directory(e)
                 .map_err(|err| std::io::Error::other(err.to_string()))?;
-            count += extract_entries_to_host(src_fs, &children, &target)?;
+            count += extract_entries_to_host(src_fs, &children, &target, fork_mode)?;
         } else {
-            let mut f = std::fs::File::create(&target)?;
-            src_fs
-                .write_file_to(e, &mut f)
-                .map_err(|err| std::io::Error::other(err.to_string()))?;
+            export_file_with_fork(src_fs, e, dest_dir, &safe_name(e), fork_mode)
+                .map_err(|err| std::io::Error::other(format!("{err:#}")))?;
             count += 1;
         }
     }

--- a/src/gui/commander/pane.rs
+++ b/src/gui/commander/pane.rs
@@ -31,7 +31,7 @@ use rusty_backup::fs::filesystem::Filesystem;
 use rusty_backup::fs::partition_is_browsable;
 use rusty_backup::model::browse_session::{BrowseOpenStatus, BrowseSession};
 use rusty_backup::model::cache_runner;
-use rusty_backup::model::commander_descend::{classify_entry, DescendKind};
+use rusty_backup::model::commander_descend::{classify_entry, open_archive, DescendKind};
 use rusty_backup::model::commander_ops::{self, ApplyStatus};
 use rusty_backup::model::commander_source;
 use rusty_backup::model::dir_listing::{type_tag, DirListing, Row, SortColumn};
@@ -40,6 +40,7 @@ use rusty_backup::model::remote_browser::{BrowseMode, BrowseTarget, RemoteBrowse
 use rusty_backup::model::status::BlockCacheScan;
 use rusty_backup::model::wrapper_tree::{TreeRow, WrapperSource, WrapperTree};
 use rusty_backup::partition::{format_size, PartitionInfo};
+use rusty_backup::update::RecentMode;
 
 use super::Side;
 
@@ -189,6 +190,14 @@ pub(crate) struct CommanderPane {
     /// The base cwd as of last frame; wrapper expansion is per-directory, so a
     /// change here (navigate / switch / close) collapses every wrapper.
     last_cwd: String,
+    /// In-memory mirror of the merged recent list (newest 3 per mode across
+    /// Inspect/Restore/Optical/Archives/Commander). Seeded at construction and
+    /// refreshed on each open; drives this pane's "Recent" dropdown.
+    recent: Vec<String>,
+    /// True when the source is a Mac archive opened in-pane (`ArchiveFilesystem`,
+    /// read-only). Copy-OUT works via the session-less path; the pane rejects
+    /// edits and receiving copies, like a wrapper mount or backup.
+    archive_source: bool,
 }
 
 /// Display cache for a remote pane (addr + what it's browsing). The live engine
@@ -288,6 +297,8 @@ impl CommanderPane {
             tree_selected: Vec::new(),
             tree_index: HashMap::new(),
             last_cwd: String::new(),
+            recent: super::super::load_recent_merged(),
+            archive_source: false,
         }
     }
 
@@ -318,6 +329,12 @@ impl CommanderPane {
     /// Clear the tree selection (e.g. when the base listing is clicked).
     fn clear_tree_selection(&mut self) {
         self.tree_selected.clear();
+    }
+
+    /// Drop this pane's in-memory recent-files mirror (the Settings dialog
+    /// cleared the persisted lists).
+    pub(crate) fn clear_recent_files(&mut self) {
+        self.recent.clear();
     }
 
     /// Expand or collapse a wrapper / inner-folder node. Opening a wrapper
@@ -992,6 +1009,7 @@ impl CommanderPane {
         self.source = None;
         self.partitions = Vec::new();
         self.resolved_backup = None;
+        self.archive_source = false;
         self.selected_part = None;
         self.session = None;
         self.queue.clear();
@@ -1079,6 +1097,19 @@ impl CommanderPane {
         )
     }
 
+    /// True when this pane is browsing a disk image on a remote daemon. Such a
+    /// pane can *receive* a copy (writes go over the daemon's Family-F write
+    /// path); a remote *host* pane can't (no host-write verb yet).
+    fn is_remote_image(&self) -> bool {
+        matches!(
+            self.remote,
+            Some(RemoteConn {
+                mode: BrowseMode::Image { .. },
+                ..
+            })
+        )
+    }
+
     fn render_switch_guard(&mut self, ctx: &egui::Context) -> Option<String> {
         // Short-circuit when nothing is pending.
         self.pending_switch.as_ref()?;
@@ -1131,10 +1162,14 @@ impl CommanderPane {
         self.listing.is_loaded()
             && self.pending_apply.is_none()
             && self.pending_open.is_none()
+            && self.pending_remote.is_none()
             && self.resolved_backup.is_none()
-            // A remote pane can be browsed and copied *out of*, but not yet
-            // copied *into* (the local→remote write path is a later increment).
-            && self.remote.is_none()
+            && !self.archive_source
+            // Local panes always OK. A remote pane can receive a copy only when
+            // it's an image: writes go to the daemon's OpenSession/StageUpload/
+            // Apply path. A remote *host* folder has no host-write verb yet, so
+            // it stays copy-out-only.
+            && (self.remote.is_none() || self.is_remote_image())
     }
 
     /// True when this pane lists a host-OS folder rather than a disk image.
@@ -1151,6 +1186,13 @@ impl CommanderPane {
     /// editable session, and Clonezilla images are read-through a block cache.
     pub(crate) fn is_backup_pane(&self) -> bool {
         self.resolved_backup.is_some()
+    }
+
+    /// True when this pane's source is a read-only Mac archive
+    /// (`ArchiveFilesystem`). Like a backup pane, it can be browsed and copied
+    /// out of, but not edited or copied into.
+    pub(crate) fn is_archive_pane(&self) -> bool {
+        self.archive_source
     }
 
     /// A clone of the session that opened this image pane (to re-open the source
@@ -1182,6 +1224,18 @@ impl CommanderPane {
         }
         if self.is_backup_pane() {
             return format!("[{}] backup panes are read-only.", self.side.label());
+        }
+        if self.archive_source {
+            return format!("[{}] archive panes are read-only.", self.side.label());
+        }
+        if self.remote.is_some() {
+            // The remote write path carries copies only; delete / rename over the
+            // wire is a follow-up. Keep remote panes copy-in-only for now.
+            return format!(
+                "[{}] remote panes accept copied files/folders only; delete over \
+                 the wire isn't supported yet.",
+                self.side.label()
+            );
         }
         let names: Vec<String> = self.listing.selection().to_vec();
         if names.is_empty() {
@@ -1268,6 +1322,43 @@ impl CommanderPane {
         Some((entry, data))
     }
 
+    /// True when this pane is browsing a remote daemon (host FS or an image on
+    /// it). Cross-pane callers use this to gate in-place edits that the remote
+    /// write path doesn't carry yet (delete / rename over the wire).
+    pub(crate) fn is_remote(&self) -> bool {
+        self.remote.is_some()
+    }
+
+    /// True when this pane is a remote *host* folder — a copy destination the
+    /// write path can't reach yet (the daemon has no host-write verb; only
+    /// remote disk images can be written). Drives the Copy button's hint.
+    pub(crate) fn is_remote_host_dest(&self) -> bool {
+        self.remote.is_some() && !self.is_remote_image()
+    }
+
+    /// Open a drag-and-dropped path as this pane's source (drag-and-drop router).
+    /// A directory opens as a host folder, a file as an image; staged edits defer
+    /// the switch behind the discard-confirmation, mirroring the source picker.
+    pub(crate) fn open_dropped(&mut self, path: PathBuf) -> String {
+        let is_dir = path.is_dir();
+        if !self.queue.is_empty() {
+            self.pending_switch = Some(if is_dir {
+                PendingSwitch::HostRoot(path)
+            } else {
+                PendingSwitch::Source(path)
+            });
+            return format!(
+                "[{}] discard staged edits to open a new source.",
+                self.side.label()
+            );
+        }
+        if is_dir {
+            self.load_host(path)
+        } else {
+            self.load_source(path)
+        }
+    }
+
     /// Push staged edits onto this pane's queue; returns how many.
     pub(crate) fn stage_edits(&mut self, edits: Vec<StagedEdit>) -> usize {
         let n = edits.len();
@@ -1283,9 +1374,9 @@ impl CommanderPane {
         let mut status = None;
 
         // Row 1: source selection + pane lifecycle (Close / Apply / Discard).
-        // Kept on its own line so the partition switcher (row 2) never gets
-        // squeezed into per-character wrapping on a narrow pane.
-        ui.horizontal(|ui| {
+        // Wrapped so the picker + lifecycle buttons flow onto a second line on a
+        // narrow pane instead of overflowing past the pane edge.
+        ui.horizontal_wrapped(|ui| {
             // Shared source picker (R1): the same ComboBox widget the Inspect
             // tab uses, here offering an image file or a host folder. Image
             // opens are not materialized (BrowseSession peels the container).
@@ -1315,10 +1406,12 @@ impl CommanderPane {
                     None => "Backup folder".to_string(),
                 }
             } else if let Some(p) = &self.source {
-                format!(
-                    "Image: {}",
-                    p.file_name().unwrap_or_default().to_string_lossy()
-                )
+                let base = p.file_name().unwrap_or_default().to_string_lossy();
+                if self.archive_source {
+                    format!("Archive: {base}")
+                } else {
+                    format!("Image: {base}")
+                }
             } else {
                 "Open image, backup, or folder...".to_string()
             };
@@ -1331,8 +1424,13 @@ impl CommanderPane {
                 // separate button).
                 show_remote: true,
                 materialize_image: false,
-                include_mac_archives: false,
+                // Surface .sit/.hqx/... in the "Open File..." dialog; a Mac
+                // archive opens read-only in-pane (ArchiveFilesystem).
+                include_mac_archives: true,
                 width: 200.0,
+                // Variable-length recent group: the merged list is already short
+                // (newest 3 per mode) and rarely changes mid-session.
+                recent_slots: 0,
             };
             let state = super::super::source_picker::PickerState {
                 selected_device_idx: None,
@@ -1340,6 +1438,9 @@ impl CommanderPane {
                 host_active: self.listing.is_host(),
                 backup_active: is_backup,
                 devices: &[],
+                // Merged recent list (newest 3 per mode) shown as a group inside
+                // this same dropdown — no extra combo crowding the source bar.
+                recent: &self.recent,
             };
             let id = format!("commander_source_{}", self.side.idx());
             if let Some(ev) =
@@ -1347,6 +1448,12 @@ impl CommanderPane {
             {
                 use super::super::source_picker::SourceEvent;
                 match ev {
+                    // A recent pick opens like a drag-and-drop: file→image/archive,
+                    // dir→host folder (deferred behind the discard prompt if edits
+                    // are staged).
+                    SourceEvent::Recent(path) => {
+                        status = Some(self.open_dropped(path));
+                    }
                     SourceEvent::Image { path, .. } => {
                         if self.queue.is_empty() {
                             status = Some(self.load_source(path));
@@ -1431,8 +1538,9 @@ impl CommanderPane {
             }
 
             // Per-pane staging controls (writable image panes only; host writes
-            // are immediate and never staged, and backups are read-only).
-            if !self.listing.is_host() && self.resolved_backup.is_none() {
+            // are immediate and never staged, and backups / archives are
+            // read-only).
+            if !self.listing.is_host() && self.resolved_backup.is_none() && !self.archive_source {
                 let n = self.queue.len();
                 let busy = self.pending_apply.is_some()
                     || self.pending_open.is_some()
@@ -1459,9 +1567,11 @@ impl CommanderPane {
             }
         });
 
-        // Row 2: partition switcher + view toggle + volume readout.
+        // Row 2: partition switcher + New Folder + volume readout. Wrapped so on
+        // a narrow pane the volume readout flows onto a second line instead of
+        // overlapping the New Folder button.
         if self.listing.is_loaded() {
-            ui.horizontal(|ui| {
+            ui.horizontal_wrapped(|ui| {
                 // Partition dropdown (image panes only; host folders have none).
                 if !self.listing.is_host() {
                     let current = self
@@ -1511,22 +1621,23 @@ impl CommanderPane {
                     });
                 }
 
-                // Right-aligned volume label + free space.
-                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    if self.listing.is_host() {
-                        ui.strong("local folder");
+                // Volume label + free space. Rendered inline (not right-aligned)
+                // so on a narrow pane it wraps to a second line rather than
+                // overflowing left into the New Folder button.
+                ui.separator();
+                if self.listing.is_host() {
+                    ui.strong("local folder");
+                } else {
+                    let label = if self.volume_label.is_empty() {
+                        self.fs_type.clone()
                     } else {
-                        let free = self.total_size.saturating_sub(self.used_size);
-                        ui.label(format!("free: {}", format_size(free)));
-                        ui.separator();
-                        let label = if self.volume_label.is_empty() {
-                            self.fs_type.clone()
-                        } else {
-                            format!("{} ({})", self.volume_label, self.fs_type)
-                        };
-                        ui.strong(label);
-                    }
-                });
+                        format!("{} ({})", self.volume_label, self.fs_type)
+                    };
+                    ui.strong(label);
+                    ui.separator();
+                    let free = self.total_size.saturating_sub(self.used_size);
+                    ui.label(format!("free: {}", format_size(free)));
+                }
             });
         }
         status
@@ -1538,6 +1649,7 @@ impl CommanderPane {
         self.source = None;
         self.partitions.clear();
         self.resolved_backup = None;
+        self.archive_source = false;
         self.cache_store.clear();
         self.selected_part = None;
         self.listing = DirListing::new();
@@ -1633,14 +1745,27 @@ impl CommanderPane {
     /// Probe a freshly-picked file and start browsing its first real partition.
     fn load_source(&mut self, path: PathBuf) -> String {
         self.source = Some(path.clone());
+        // Record in the Commander recent MRU (single choke point for local image
+        // opens: picker, recent quick-pick, drag-and-drop, deferred switch), then
+        // refresh this pane's merged view.
+        super::super::push_recent(RecentMode::Commander, &path);
+        self.recent = super::super::load_recent_merged();
         self.listing = DirListing::new();
         self.resolved_backup = None;
+        self.archive_source = false;
         self.cache_store.clear();
         self.pending_open = None;
         self.error = None;
         self.selected_part = None;
         self.volume_label.clear();
         self.fs_type.clear();
+
+        // A Mac archive (.sit / .hqx / .sea / .cpt / .mar) isn't a disk image —
+        // open it read-only in-pane as an ArchiveFilesystem instead of parsing a
+        // (nonexistent) partition table.
+        if is_mac_archive_path(&path) {
+            return self.load_archive(path);
+        }
 
         match commander_source::probe_partitions(&path) {
             Ok(parts) => {
@@ -1664,6 +1789,49 @@ impl CommanderPane {
         }
     }
 
+    /// Open a Mac archive as a read-only in-pane source (`ArchiveFilesystem`).
+    /// Synchronous — archives decode fully in memory, so there's no worker
+    /// thread; this is the same install `poll_open` does, minus the partition
+    /// machinery. Copy-OUT (both forks) flows through the session-less path.
+    fn load_archive(&mut self, path: PathBuf) -> String {
+        self.partitions.clear();
+        self.selected_part = None;
+        self.session = None;
+        self.queue.clear();
+        let label = path.file_name().map(|n| n.to_string_lossy().into_owned());
+        let mut fs = match open_archive(&path, label) {
+            Ok(fs) => fs,
+            Err(e) => {
+                self.error = Some(format!("Could not open archive: {e:#}"));
+                return format!("[{}] failed to open {}", self.side.label(), path.display());
+            }
+        };
+        let root = match fs.root() {
+            Ok(r) => r,
+            Err(e) => {
+                self.error = Some(format!("Could not read archive root: {e}"));
+                return format!("[{}] failed to open {}", self.side.label(), path.display());
+            }
+        };
+        let entries = match fs.list_directory(&root) {
+            Ok(e) => e,
+            Err(e) => {
+                self.error = Some(format!("Could not list archive: {e}"));
+                return format!("[{}] failed to open {}", self.side.label(), path.display());
+            }
+        };
+        self.volume_label = fs.volume_label().unwrap_or_default().to_string();
+        self.fs_type = fs.fs_type().to_string();
+        self.archive_source = true;
+        let n = entries.len();
+        self.listing.load_root(fs, root, entries, false);
+        format!(
+            "[{}] opened archive {} ({n} item(s)).",
+            self.side.label(),
+            path.display()
+        )
+    }
+
     /// Open a backup folder — native rusty-backup *or* Clonezilla (the shared
     /// resolver detects which) — and start browsing its first browsable
     /// partition. The partition dropdown lists the backed-up partitions;
@@ -1672,6 +1840,7 @@ impl CommanderPane {
         self.source = Some(folder.clone());
         self.listing = DirListing::new();
         self.resolved_backup = None;
+        self.archive_source = false;
         self.cache_store.clear();
         self.partitions.clear();
         self.session = None;
@@ -1711,6 +1880,7 @@ impl CommanderPane {
     fn load_host(&mut self, dir: PathBuf) -> String {
         self.source = Some(dir.clone());
         self.resolved_backup = None;
+        self.archive_source = false;
         self.cache_store.clear();
         self.partitions.clear();
         self.selected_part = None;
@@ -1914,6 +2084,10 @@ impl CommanderPane {
         if self.queue.is_empty() {
             return String::new();
         }
+        // A remote image pane has no local BrowseSession — apply over the wire.
+        if self.is_remote_image() {
+            return self.apply_remote();
+        }
         let Some(session) = self.session.clone() else {
             return format!("[{}] no source to apply to.", self.side.label());
         };
@@ -1922,6 +2096,44 @@ impl CommanderPane {
         self.pending_apply = Some(commander_ops::spawn_apply(session, edits));
         self.error = None;
         format!("[{}] applying {n} edit(s)...", self.side.label())
+    }
+
+    /// Apply the staged queue to a remote image over the Family-F write path
+    /// (`OpenSession` → `StageUpload`/`StageMkdir` → `Apply`), bound to the same
+    /// `(image_path, partition)` the pane is browsing so the daemon resolves the
+    /// partition exactly as it did for the browse. Only copy-in edits travel
+    /// over the wire, so a queue containing anything else is refused here (before
+    /// spawning) rather than half-applied.
+    fn apply_remote(&mut self) -> String {
+        let (addr, path, partition) = match &self.remote {
+            Some(RemoteConn {
+                addr,
+                mode: BrowseMode::Image { path, partition },
+            }) => (addr.clone(), path.clone(), *partition),
+            _ => return format!("[{}] no remote image to apply to.", self.side.label()),
+        };
+        if self.queue.iter().any(|e| {
+            !matches!(
+                e,
+                StagedEdit::AddFile { .. } | StagedEdit::CreateDirectory { .. }
+            )
+        }) {
+            return format!(
+                "[{}] remote panes accept copied files/folders only; delete / \
+                 rename over the wire isn't supported yet.",
+                self.side.label()
+            );
+        }
+        let n = self.queue.len();
+        let edits: Vec<StagedEdit> = self.queue.iter().cloned().collect();
+        self.pending_apply = Some(commander_ops::spawn_remote_apply(
+            addr, path, partition, edits,
+        ));
+        self.error = None;
+        format!(
+            "[{}] uploading {n} item(s) to the remote image...",
+            self.side.label()
+        )
     }
 
     /// Poll an in-flight apply; on success, re-open the source so the listing
@@ -1946,6 +2158,22 @@ impl CommanderPane {
         // catalog before the write, so a plain reload would show stale data.
         if let Some(i) = self.selected_part {
             self.open_partition(i);
+        } else if self.is_remote_image() {
+            // Same staleness on the remote side: the daemon's browse handle
+            // snapshotted the catalog before the separate write session
+            // committed. Re-open the image on a fresh handle (returns to the
+            // volume root) so the copied files appear.
+            let reopen = match &self.remote {
+                Some(RemoteConn {
+                    mode: BrowseMode::Image { path, partition },
+                    ..
+                }) => Some((path.clone(), *partition)),
+                _ => None,
+            };
+            if let Some((path, partition)) = reopen {
+                let from = remote_parent_dir(&path);
+                let _ = self.spawn_open_image(path, partition, from);
+            }
         }
         let msg = format!("[{}] applied {n} edit(s).", self.side.label());
         self.log_events.push(msg.clone());
@@ -2441,6 +2669,30 @@ fn read_host_file_capped(path: &str, max: usize) -> Option<Vec<u8>> {
     Some(buf)
 }
 
+/// True for a Mac-archive file path (`.sit`/`.hqx`/`.sea`/`.cpt`/`.mar`). Such a
+/// file isn't a disk image — a Commander pane opens it read-only in-pane as an
+/// `ArchiveFilesystem` instead of parsing a partition table.
+fn is_mac_archive_path(path: &std::path::Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|ext| {
+            rusty_backup::model::file_types::MAC_ARCHIVE_EXTS
+                .iter()
+                .any(|a| a.eq_ignore_ascii_case(ext))
+        })
+        .unwrap_or(false)
+}
+
+/// The parent directory of a daemon-side path (`/a/b/c.img` -> `/a/b`). Used as
+/// the "opened from" host dir when re-opening a remote image after a write so
+/// "Close Image" still returns near where the image lives.
+fn remote_parent_dir(path: &str) -> String {
+    match path.rfind('/') {
+        Some(0) | None => "/".to_string(),
+        Some(i) => path[..i].to_string(),
+    }
+}
+
 /// How a row participates in the staged-edit overlay.
 #[derive(Clone, Copy, PartialEq)]
 enum RowKind {
@@ -2675,13 +2927,15 @@ struct Cols {
 
 fn cols(rect: egui::Rect) -> Cols {
     let pad = 6.0;
-    let gap = 10.0;
-    let type_w = 56.0;
-    let mod_w = 134.0;
-    let size_w = 76.0;
-    let rsrc_w = 76.0;
+    let gap = 8.0;
+    // Trimmed fixed columns so the Name column isn't starved at the default
+    // pane width (~500 px): footprint here is ~334 px vs the old ~392 px.
+    let type_w = 50.0;
+    let mod_w = 112.0;
+    let size_w = 66.0;
+    let rsrc_w = 66.0;
     let name_l = rect.left() + pad;
-    let name_w = (rect.width() - type_w - mod_w - size_w - rsrc_w - 5.0 * gap).max(60.0);
+    let name_w = (rect.width() - type_w - mod_w - size_w - rsrc_w - 5.0 * gap).max(90.0);
     let name_r = name_l + name_w;
     let size_l = name_r + gap;
     let size_r = size_l + size_w;

--- a/src/gui/inspect_tab.rs
+++ b/src/gui/inspect_tab.rs
@@ -67,6 +67,10 @@ fn is_mac_archive_path(path: &std::path::Path) -> bool {
 }
 
 pub struct InspectTab {
+    /// In-memory mirror of the Inspect mode's recent-image MRU (config.json).
+    /// Seeded at construction, refreshed on each image open; drives the source
+    /// picker's "Recent" group.
+    recent_files: Vec<String>,
     /// Index into the device list, or None if "Open Image File..." is selected
     selected_device_idx: Option<usize>,
     /// Path to an image file (when using file picker instead of device)
@@ -258,6 +262,7 @@ pub struct InspectTab {
 impl Default for InspectTab {
     fn default() -> Self {
         Self {
+            recent_files: super::load_recent(rusty_backup::update::RecentMode::Inspect),
             selected_device_idx: None,
             image_file_path: None,
             amiga_tempdir: None,
@@ -385,9 +390,20 @@ impl InspectTab {
     pub fn load_image_with_tempdir(&mut self, path: PathBuf, guard: Option<tempfile::TempDir>) {
         self.selected_device_idx = None;
         self.backup_folder_path = None;
+        // Record in the Inspect recent-image MRU. Single choke point for every
+        // image open (picker, recent quick-pick, drag-and-drop, argv, and the
+        // Archives-tab "Mount in new Inspect tab" hand-off).
+        self.recent_files = super::push_recent(rusty_backup::update::RecentMode::Inspect, &path);
         self.image_file_path = Some(path);
         self.amiga_tempdir = guard;
         self.clear_results();
+    }
+
+    /// Drop this tab's in-memory recent-files mirror. Called when the Settings
+    /// dialog clears the persisted lists (config is the source of truth; the
+    /// mirror otherwise only reloads at construction).
+    pub(crate) fn clear_recent_files(&mut self) {
+        self.recent_files.clear();
     }
 
     /// Sniff `path` to decide whether it is a floppy container (XDF / HDM
@@ -484,6 +500,12 @@ impl InspectTab {
             // Shared source picker (R1): same ComboBox widget the Commander
             // panes use. It owns the rfd dialogs + image filter/materialize and
             // emits a SourceEvent; we map that onto our source state here.
+            //
+            // Plain fixed width. A wider box just spreads the short device /
+            // action rows across the whole window (the "awkward" full-width look);
+            // egui truncates a long selected label to fit, and the open popup
+            // still extends per-row to show full names. Recents render as a
+            // "Recent" group at the TOP of this same dropdown (PickerState.recent).
             let cfg = super::source_picker::PickerConfig {
                 show_devices: true,
                 show_image: true,
@@ -493,6 +515,9 @@ impl InspectTab {
                 materialize_image: true,
                 include_mac_archives: true,
                 width: 400.0,
+                // Fixed 5-row "Recent" group: constant popup height as files are
+                // opened, so egui's cached-popup-size bug never bites here.
+                recent_slots: 5,
             };
             let state = super::source_picker::PickerState {
                 selected_device_idx: self.selected_device_idx,
@@ -500,10 +525,32 @@ impl InspectTab {
                 host_active: false,
                 backup_active: self.backup_folder_path.is_some(),
                 devices: ctx.devices,
+                recent: &self.recent_files,
             };
             if let Some(ev) =
                 super::source_picker::show(ui, "inspect_source", &cfg, &current_label, &state)
             {
+                use super::source_picker::SourceEvent;
+                // A "Recent" pick is a raw path; materialize it and treat it as
+                // an image open, exactly like re-picking the file (Inspect only
+                // records images into its recent list).
+                let ev = if let SourceEvent::Recent(path) = ev {
+                    match super::prepare_disk_image_path(&path, false) {
+                        Ok((materialized, guard)) => SourceEvent::Image {
+                            path: materialized,
+                            tempdir: guard,
+                        },
+                        Err(e) => {
+                            log::error!("Failed to decompress {}: {}", path.display(), e);
+                            SourceEvent::Image {
+                                path,
+                                tempdir: None,
+                            }
+                        }
+                    }
+                } else {
+                    ev
+                };
                 // "Connect to Remote..." opens the inline remote panel; any other
                 // source ends a remote session and switches to that local source.
                 if matches!(ev, super::source_picker::SourceEvent::Remote) {
@@ -2759,6 +2806,9 @@ impl InspectTab {
             // "Connect to Remote..." is intercepted at the call site (it pops a
             // window rather than changing the source); never reaches here.
             SourceEvent::Remote => {}
+            // A recent pick is translated to `Image` at the call site before
+            // reaching here (materialized), so this arm is unreachable.
+            SourceEvent::Recent(_) => {}
         }
     }
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -40,7 +40,7 @@ use settings_dialog::SettingsDialog;
 use std::path::PathBuf;
 
 use rusty_backup::device::{self, DiskDevice};
-use rusty_backup::update::{check_for_updates, UpdateConfig, UpdateInfo};
+use rusty_backup::update::{check_for_updates, RecentMode, UpdateConfig, UpdateInfo};
 
 #[cfg(target_os = "linux")]
 use elevation_dialog::{ElevationAction, ElevationDialog};
@@ -98,6 +98,108 @@ fn physical_devices_available() -> bool {
     {
         true
     }
+}
+
+/// Record `path` in the per-mode recent-files MRU (persisted in config.json)
+/// and return the updated newest-first list for `mode`. Mirrors the Optical
+/// tab's `remember_daemon_addr` write-through: config.json is the source of
+/// truth and each tab keeps an in-memory mirror it refreshes from this return
+/// value. Loading + saving on every open is cheap (a small JSON file) and keeps
+/// the history durable across runs without an eframe `save()` hook.
+pub(crate) fn push_recent(mode: RecentMode, path: &std::path::Path) -> Vec<String> {
+    let mut cfg = UpdateConfig::load();
+    cfg.remember_file(mode, &path.display().to_string());
+    let list = cfg.recent_files.list(mode).to_vec();
+    let _ = cfg.save();
+    list
+}
+
+/// The persisted recent-files list for `mode` (newest first). Used to seed a
+/// tab's in-memory mirror at construction.
+pub(crate) fn load_recent(mode: RecentMode) -> Vec<String> {
+    UpdateConfig::load().recent_files.list(mode).to_vec()
+}
+
+/// A merged recent list for Commander: the newest 3 entries from each mode's
+/// list (deduped, category order Inspect→Restore→Optical→Archives→Commander).
+/// Commander opens any of them (image / backup folder), so one combined
+/// quick-pick beats five separate ones.
+pub(crate) fn load_recent_merged() -> Vec<String> {
+    let cfg = UpdateConfig::load();
+    let mut out = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for mode in [
+        RecentMode::Inspect,
+        RecentMode::Restore,
+        RecentMode::Optical,
+        RecentMode::Archives,
+        RecentMode::Commander,
+        RecentMode::Backup,
+    ] {
+        for p in cfg.recent_files.list(mode).iter().take(3) {
+            if seen.insert(p.clone()) {
+                out.push(p.clone());
+            }
+        }
+    }
+    out
+}
+
+/// A dedicated "Recent" dropdown (its own popup, so it never gets clipped inside
+/// the source-picker combo). Lists each entry's basename with the full path on
+/// hover; returns the picked path. Renders nothing for an empty list. `id_salt`
+/// keys the ComboBox (callers that draw more than one per frame must differ).
+///
+/// `slots`: when non-zero, always draw exactly that many rows — the newest
+/// entries fill them and the rest are dimmed placeholders — so the popup's
+/// height never changes as the list grows, dodging egui's cached-popup-size bug
+/// (see [`source_picker`]'s `recent_slots`). `0` draws one row per entry
+/// (variable height). Either way the whole combo is hidden when there are no
+/// recents, so an empty list never shows a dropdown of blanks.
+pub(crate) fn recent_combo(
+    ui: &mut egui::Ui,
+    id_salt: &str,
+    recent: &[String],
+    slots: usize,
+) -> Option<PathBuf> {
+    if recent.is_empty() {
+        return None;
+    }
+    let mut chosen = None;
+    let row = |ui: &mut egui::Ui, chosen: &mut Option<PathBuf>, p: &str| {
+        let label = std::path::Path::new(p)
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| p.to_string());
+        if ui.selectable_label(false, label).on_hover_text(p).clicked() {
+            *chosen = Some(PathBuf::from(p));
+        }
+    };
+    egui::ComboBox::from_id_salt(id_salt)
+        .selected_text("Recent...")
+        .width(240.0)
+        .height(400.0)
+        .show_ui(ui, |ui| {
+            if slots > 0 {
+                for slot in 0..slots {
+                    match recent.get(slot) {
+                        Some(p) => row(ui, &mut chosen, p),
+                        // Placeholder keeps the row count (and popup height) fixed.
+                        None => {
+                            ui.add_enabled(
+                                false,
+                                egui::Button::selectable(false, egui::RichText::new("-").weak()),
+                            );
+                        }
+                    }
+                }
+            } else {
+                for p in recent {
+                    row(ui, &mut chosen, p);
+                }
+            }
+        });
+    chosen
 }
 
 fn file_dialog() -> rfd::FileDialog {
@@ -733,22 +835,45 @@ impl eframe::App for RustyBackupApp {
             self.open_in_inspect(path);
         }
 
-        // Drag-and-drop: if the user dragged one or more files onto the
-        // app window, take the first one with a real filesystem path and
-        // open it in the Inspect tab. `with_drag_and_drop(true)` is set
-        // on the viewport in main.rs so eframe surfaces these events.
+        // Drag-and-drop: route the first dropped file with a real filesystem
+        // path to the *currently active* mode. `with_drag_and_drop(true)` is set
+        // on the viewport in main.rs so eframe surfaces these events. This
+        // reads (does not consume) `dropped_files`, exactly like the per-volume
+        // browse handlers, so a drop into a loaded volume still reaches that
+        // volume's own edit handler where applicable.
         //
-        // Only steal the drop to open a NEW source when nothing is loaded.
-        // Once a source is loaded, drops belong to the filesystem browser's
-        // own handler (BrowseView::handle_dropped_files), which adds the
-        // dropped file into the open volume while in edit mode — re-opening
-        // the drop as a new image here would clobber the loaded source and
-        // make drag-to-add impossible.
-        if !self.inspect_tab.has_loaded_source() {
-            let dropped: Option<PathBuf> =
-                ctx.input(|i| i.raw.dropped_files.iter().find_map(|f| f.path.clone()));
-            if let Some(path) = dropped {
-                self.open_in_inspect(path);
+        // Historically this always opened in Inspect, which made drag-and-drop
+        // useless for the Optical / Archives / Restore tabs and Commander.
+        let dropped: Option<PathBuf> =
+            ctx.input(|i| i.raw.dropped_files.iter().find_map(|f| f.path.clone()));
+        if let Some(path) = dropped {
+            if let Some(cmd) = self.commander.as_mut() {
+                // Commander overlay takes over the frame; hand the drop to the
+                // active pane (opens it as an image / host folder there).
+                cmd.open_dropped_path(path);
+            } else {
+                match self.active_tab {
+                    // Inspect: only steal the drop to open a NEW source when
+                    // nothing is loaded. Once a source is loaded the drop belongs
+                    // to BrowseView::handle_dropped_files (drag-to-add into the
+                    // open volume while in edit mode) — re-opening here would
+                    // clobber the loaded source and make drag-to-add impossible.
+                    Tab::Inspect => {
+                        if !self.inspect_tab.has_loaded_source() {
+                            self.open_in_inspect(path);
+                        }
+                    }
+                    // Optical: don't clobber an open disc browse (optical
+                    // browsing has no drag-to-add of its own).
+                    Tab::Optical => {
+                        if !self.optical_tab.is_browsing() {
+                            self.optical_tab.open_image(path);
+                        }
+                    }
+                    Tab::Archives => self.archives_tab.open_path(path),
+                    Tab::Restore => self.restore_tab.open_dropped(path),
+                    Tab::Backup => self.backup_tab.open_image(path),
+                }
             }
         }
 
@@ -1116,5 +1241,19 @@ impl eframe::App for RustyBackupApp {
 
         // Show settings dialog if open
         self.settings_dialog.show(ctx);
+
+        // The Settings "Clear Recent Files" button clears + persists the config
+        // itself; here we also drop the in-memory mirrors each tab / Commander
+        // pane holds (they only reload from config at construction otherwise).
+        if self.settings_dialog.take_clear_recents() {
+            self.inspect_tab.clear_recent_files();
+            self.restore_tab.clear_recent_files();
+            self.optical_tab.clear_recent_files();
+            self.archives_tab.clear_recent_files();
+            self.backup_tab.clear_recent_files();
+            if let Some(cmd) = self.commander.as_mut() {
+                cmd.clear_recent_files();
+            }
+        }
     }
 }

--- a/src/gui/optical_tab.rs
+++ b/src/gui/optical_tab.rs
@@ -62,6 +62,9 @@ pub struct OpticalTab {
     /// MRU of daemon addresses (newest first), mirrored to `config.json` — the
     /// "Add remote daemon" dialog's quick-pick list.
     recent_daemons: Vec<String>,
+    /// MRU of opened disc-image paths (newest first), mirrored to `config.json`
+    /// — the image-file "Recent:" quick-pick row.
+    recent_files: Vec<String>,
     image_file_path: Option<PathBuf>,
     disc_info: Option<DiscImageInfo>,
     disc_info_error: Option<String>,
@@ -98,6 +101,7 @@ impl Default for OpticalTab {
             add_remote_error: None,
             add_remote_status: None,
             recent_daemons: UpdateConfig::load().recent_daemon_addrs,
+            recent_files: super::load_recent(rusty_backup::update::RecentMode::Optical),
             image_file_path: None,
             disc_info: None,
             disc_info_error: None,
@@ -162,6 +166,28 @@ impl OpticalTab {
 
     pub fn drive_count(&self) -> usize {
         self.rip_devices.len()
+    }
+
+    /// True while a disc's contents are being browsed. The drag-and-drop router
+    /// checks this so dropping a file mid-browse doesn't clobber the open disc.
+    pub fn is_browsing(&self) -> bool {
+        self.browse_view.is_active()
+    }
+
+    /// Open `path` as the image-file source (used by the drag-and-drop router
+    /// when the Optical tab is active). Sets the source mode to Image file and
+    /// points at the dropped path; `show()` auto-detects the disc on the next
+    /// frame via the `image_file_path != prev_image_path` check.
+    pub fn open_image(&mut self, path: PathBuf) {
+        self.source_mode = SourceMode::ImageFile;
+        self.recent_files = super::push_recent(rusty_backup::update::RecentMode::Optical, &path);
+        self.image_file_path = Some(path);
+    }
+
+    /// Drop this tab's in-memory recent-files mirror (the Settings dialog clears
+    /// the persisted lists; the mirror otherwise only reloads at construction).
+    pub(crate) fn clear_recent_files(&mut self) {
+        self.recent_files.clear();
     }
 
     /// Poll the background "Add remote daemon" connect; on success add the
@@ -399,8 +425,13 @@ impl OpticalTab {
                                 .add_filter("All Files", &["*"])
                                 .pick_file()
                             {
-                                self.image_file_path = Some(path);
+                                self.open_image(path);
                             }
+                        }
+                        if let Some(path) =
+                            super::recent_combo(ui, "optical_recent", &self.recent_files, 5)
+                        {
+                            self.open_image(path);
                         }
                     });
                 }

--- a/src/gui/restore_tab.rs
+++ b/src/gui/restore_tab.rs
@@ -105,6 +105,10 @@ pub struct RestoreTab {
     // Mode
     restore_mode: RestoreMode,
 
+    /// MRU of opened backup-folder paths (newest first), mirrored to
+    /// `config.json` — the "Recent:" quick-pick row.
+    recent_files: Vec<String>,
+
     // Source (Full Disk + Single Partition)
     backup_folder: Option<PathBuf>,
     backup_metadata: Option<BackupMetadata>,
@@ -188,6 +192,7 @@ impl Default for RestoreTab {
     fn default() -> Self {
         Self {
             restore_mode: RestoreMode::FullDisk,
+            recent_files: super::load_recent(rusty_backup::update::RecentMode::Restore),
             backup_folder: None,
             backup_metadata: None,
             clonezilla_image: None,
@@ -245,6 +250,40 @@ impl RestoreTab {
             // Force reload on next show
             self.prev_backup_folder = None;
         }
+    }
+
+    /// Open a dropped path (drag-and-drop router). A directory is treated as a
+    /// backup folder (full-disk restore); a file is treated as a single-
+    /// partition source image. Mirrors the tab's two `Browse...` handlers so
+    /// drag-and-drop behaves the same as the picker.
+    pub fn open_dropped(&mut self, path: PathBuf) {
+        if path.is_dir() {
+            self.restore_mode = RestoreMode::FullDisk;
+            self.load_backup(&path);
+        } else {
+            self.restore_mode = RestoreMode::SinglePartition;
+            match super::prepare_disk_image_path(&path, true) {
+                Ok((materialized, guard)) => {
+                    self.sp_image_file = Some(materialized);
+                    self.sp_amiga_tempdir = guard;
+                }
+                Err(e) => {
+                    log::error!("Failed to decompress {}: {}", path.display(), e);
+                    self.sp_image_file = Some(path);
+                    self.sp_amiga_tempdir = None;
+                }
+            }
+            self.backup_folder = None;
+            self.backup_metadata = None;
+            self.sp_source_partition_idx = None;
+            self.prev_backup_folder = None;
+        }
+    }
+
+    /// Drop this tab's in-memory recent-files mirror (the Settings dialog clears
+    /// the persisted lists; the mirror otherwise only reloads at construction).
+    pub(crate) fn clear_recent_files(&mut self) {
+        self.recent_files.clear();
     }
 
     pub fn clear_backup(&mut self) {
@@ -330,6 +369,11 @@ impl RestoreTab {
                 }
             });
         });
+        if controls_enabled {
+            if let Some(path) = super::recent_combo(ui, "restore_recent", &self.recent_files, 0) {
+                self.open_dropped(path);
+            }
+        }
 
         // Auto-load metadata when folder changes
         if !self.restore_running {
@@ -1121,6 +1165,10 @@ impl RestoreTab {
             Some(f) => f.clone(),
             None => return,
         };
+        // Single choke point for backup-folder opens across all three restore
+        // modes (they each call this on a folder change): record in the Restore
+        // recent-backups MRU.
+        self.recent_files = super::push_recent(rusty_backup::update::RecentMode::Restore, &folder);
 
         let metadata_path = folder.join("metadata.json");
         if metadata_path.exists() {

--- a/src/gui/settings_dialog.rs
+++ b/src/gui/settings_dialog.rs
@@ -7,6 +7,14 @@ pub struct SettingsDialog {
     update_check_enabled: bool,
     update_repo_url: String,
     status_message: Option<String>,
+    /// Total recent-file entries across all modes, shown on the "Clear Recent
+    /// Files" button. Refreshed when the dialog opens and zeroed after a clear.
+    recent_count: usize,
+    /// Set when the user clears the recent lists, so the app can also drop the
+    /// in-memory mirrors each tab / Commander pane holds (config alone is the
+    /// source of truth, but those mirrors only reload at construction). Consumed
+    /// via [`Self::take_clear_recents`].
+    clear_recents_requested: bool,
     /// Windows only: register Rusty Backup as a handler for disk-image files.
     #[cfg(windows)]
     file_associations_enabled: bool,
@@ -78,6 +86,28 @@ impl SettingsDialog {
                         ui.add_space(10.0);
                     }
 
+                    ui.separator();
+                    ui.add_space(10.0);
+                    ui.heading("Recent Files");
+                    ui.add_space(10.0);
+                    ui.label(
+                        "Forget the recently-opened file lists shown in the Inspect, \
+                         Restore, Optical, Archives, and Commander source pickers.",
+                    );
+                    ui.add_space(5.0);
+                    let clear_label = if self.recent_count > 0 {
+                        format!("Clear Recent Files ({})", self.recent_count)
+                    } else {
+                        "Clear Recent Files".to_string()
+                    };
+                    if ui
+                        .add_enabled(self.recent_count > 0, egui::Button::new(clear_label))
+                        .clicked()
+                    {
+                        self.clear_recent_files();
+                    }
+                    ui.add_space(10.0);
+
                     if let Some(ref msg) = self.status_message {
                         ui.colored_label(
                             if msg.starts_with("Error") {
@@ -111,12 +141,43 @@ impl SettingsDialog {
         let config = UpdateConfig::load();
         self.update_check_enabled = config.update_check.enabled;
         self.update_repo_url = config.update_check.repository_url;
+        self.recent_count = config.recent_files.total();
+        self.clear_recents_requested = false;
         #[cfg(windows)]
         {
             self.file_associations_enabled = config.file_associations_enabled;
         }
         self.status_message = None;
         self.open = true;
+    }
+
+    /// Forget every mode's recent-files list: clear + persist config now, and
+    /// flag the app to drop the tabs' in-memory mirrors (see
+    /// [`Self::take_clear_recents`]).
+    fn clear_recent_files(&mut self) {
+        let mut config = UpdateConfig::load();
+        let count = config.recent_files.total();
+        config.recent_files.clear();
+        match config.save() {
+            Ok(_) => {
+                self.recent_count = 0;
+                self.clear_recents_requested = true;
+                self.status_message = Some(if count == 1 {
+                    "Cleared 1 recent file.".to_string()
+                } else {
+                    format!("Cleared {count} recent files.")
+                });
+            }
+            Err(e) => {
+                self.status_message = Some(format!("Error clearing recent files: {e}"));
+            }
+        }
+    }
+
+    /// True once (then resets) after the user clears recents, so the app can
+    /// wipe the in-memory mirrors each tab / Commander pane holds.
+    pub fn take_clear_recents(&mut self) -> bool {
+        std::mem::take(&mut self.clear_recents_requested)
     }
 
     fn save_settings(&mut self) {

--- a/src/gui/source_picker.rs
+++ b/src/gui/source_picker.rs
@@ -37,6 +37,11 @@ pub enum SourceEvent {
     /// The user chose "Connect to Remote..." — open the remote file-browser
     /// window. The connection details are gathered by that window, not here.
     Remote,
+    /// A recently-opened path was picked from the "Recent" group. The raw path
+    /// is returned un-materialized; the caller routes it (image / archive /
+    /// backup folder) exactly as it would a drag-and-drop, so a mixed recent
+    /// list (Commander's is merged across modes) opens correctly.
+    Recent(PathBuf),
 }
 
 /// Which entries the picker offers.
@@ -62,6 +67,14 @@ pub struct PickerConfig {
     pub include_mac_archives: bool,
     /// ComboBox width.
     pub width: f32,
+    /// Render the "Recent" group as this many **fixed** rows — the newest
+    /// entries fill the slots and any remainder shows as dimmed placeholders —
+    /// so the row count (and thus the popup height) never changes as files are
+    /// opened. This sidesteps a known egui bug where a ComboBox popup caches its
+    /// height on first open and never regrows when its content later gets taller
+    /// (emilk/egui#5225, #5138). `0` keeps the old behavior: show every recent
+    /// entry, variable height (used by Commander, whose merged list is short).
+    pub recent_slots: usize,
 }
 
 /// Current selection highlight state, so the open entries render "active" and
@@ -72,6 +85,11 @@ pub struct PickerState<'a> {
     pub host_active: bool,
     pub backup_active: bool,
     pub devices: &'a [DiskDevice],
+    /// Recently-opened paths for this mode (newest first). Rendered as a
+    /// "Recent" group at the **top** of the dropdown (so it's visible without
+    /// scrolling past a long device list); a click emits [`SourceEvent::Recent`].
+    /// Empty to omit the group.
+    pub recent: &'a [String],
 }
 
 /// Run the disk-image / container file dialog (Disk Images + Mac archives +
@@ -120,11 +138,66 @@ pub fn show(
     state: &PickerState,
 ) -> Option<SourceEvent> {
     let mut event = None;
+    // Grow the dropdown to the room actually available in the window instead of
+    // a fixed cap. egui uses `.height()` as the max height of the popup's inner
+    // scroll area; a fixed 400px scrolled the moment recents + devices + open
+    // actions exceeded it (and plugging in more devices only made that worse).
+    // We size it to the space below the button — or above, whichever is larger,
+    // since egui flips the popup up when the button sits near the bottom — so
+    // every row shows when the window can fit it, and a scrollbar only appears
+    // when the window itself is genuinely too short. (Leaving `.height()` unset
+    // would fall back to egui's even smaller 200px default, not "uncapped".)
+    let window = ui.ctx().content_rect();
+    let button_top = ui.cursor().top();
+    let room_below = window.bottom() - button_top - ui.spacing().interact_size.y - 16.0;
+    let room_above = button_top - window.top() - 16.0;
+    let popup_max_height = room_below.max(room_above).max(120.0);
     egui::ComboBox::from_id_salt(id_salt)
         .selected_text(current_label)
         .width(cfg.width)
-        .height(400.0) // Show many devices without scrolling.
+        .height(popup_max_height)
         .show_ui(ui, |ui| {
+            // Recent files first, so they're visible without scrolling past a
+            // long device list. A click routes back through the caller (image /
+            // archive / backup folder), un-materialized.
+            //
+            // When `recent_slots` is set we always draw that many rows (newest
+            // entries fill them, the rest are dimmed placeholders) so the popup's
+            // height is constant as files are opened — see `recent_slots` for the
+            // egui bug this dodges. `0` falls back to a plain variable-length list.
+            let render_recent_row =
+                |ui: &mut egui::Ui, event: &mut Option<SourceEvent>, p: &str| {
+                    let label = std::path::Path::new(p)
+                        .file_name()
+                        .map(|n| n.to_string_lossy().into_owned())
+                        .unwrap_or_else(|| p.to_string());
+                    if ui.selectable_label(false, label).on_hover_text(p).clicked() {
+                        *event = Some(SourceEvent::Recent(PathBuf::from(p)));
+                    }
+                };
+            if cfg.recent_slots > 0 {
+                ui.label(egui::RichText::new("Recent").weak());
+                for slot in 0..cfg.recent_slots {
+                    match state.recent.get(slot) {
+                        Some(p) => render_recent_row(ui, &mut event, p),
+                        // Dimmed, non-interactive placeholder — holds the row so
+                        // the list height doesn't change when it later fills in.
+                        None => {
+                            ui.add_enabled(
+                                false,
+                                egui::Button::selectable(false, egui::RichText::new("-").weak()),
+                            );
+                        }
+                    }
+                }
+                ui.separator();
+            } else if !state.recent.is_empty() {
+                ui.label(egui::RichText::new("Recent").weak());
+                for p in state.recent {
+                    render_recent_row(ui, &mut event, p);
+                }
+                ui.separator();
+            }
             if cfg.show_devices {
                 for (i, device) in state.devices.iter().enumerate() {
                     let selected = state.selected_device_idx == Some(i);

--- a/src/model/commander_ops.rs
+++ b/src/model/commander_ops.rs
@@ -21,7 +21,8 @@ use anyhow::{Context, Result};
 
 use crate::fs::entry::{EntryType, FileEntry};
 use crate::fs::filesystem::Filesystem;
-use crate::fs::resource_fork::ImportedResourceFork;
+use crate::fs::fork_export::{export_file_with_fork, safe_name};
+use crate::fs::resource_fork::{ImportedResourceFork, ResourceForkMode};
 use crate::model::browse_session::BrowseSession;
 use crate::model::edit_queue::{apply_edit, StagedEdit};
 
@@ -238,11 +239,13 @@ fn host_children(path: &str) -> Vec<FileEntry> {
 
 /// An immediate (unstaged) host-write copy, run on a worker thread.
 pub enum HostCopyJob {
-    /// Extract image-volume `entries` into the host directory `dest_dir`.
+    /// Extract image-volume `entries` into the host directory `dest_dir`,
+    /// preserving resource forks per `fork_mode`.
     ImageToHost {
         session: BrowseSession,
         entries: Vec<FileEntry>,
         dest_dir: PathBuf,
+        fork_mode: ResourceForkMode,
     },
     /// Copy host `entries` into the host directory `dest_dir`.
     HostToHost {
@@ -284,9 +287,10 @@ fn run_host_copy(job: HostCopyJob) -> Result<usize> {
             session,
             entries,
             dest_dir,
+            fork_mode,
         } => {
             let mut fs = session.open().context("opening source image")?;
-            copy_image_entries_to_host(fs.as_mut(), &entries, &dest_dir)
+            copy_image_entries_to_host(fs.as_mut(), &entries, &dest_dir, fork_mode)
         }
         HostCopyJob::HostToHost { entries, dest_dir } => {
             copy_host_entries_to_host(&entries, &dest_dir)
@@ -294,11 +298,14 @@ fn run_host_copy(job: HostCopyJob) -> Result<usize> {
     }
 }
 
-/// Extract image `entries` (data fork) into `dest_dir`, recursing directories.
+/// Extract image `entries` into `dest_dir`, recursing directories and
+/// preserving resource forks per `fork_mode` (via the shared
+/// [`export_file_with_fork`]).
 fn copy_image_entries_to_host(
     fs: &mut dyn Filesystem,
     entries: &[FileEntry],
     dest_dir: &Path,
+    fork_mode: ResourceForkMode,
 ) -> Result<usize> {
     let mut count = 0;
     for entry in entries {
@@ -308,12 +315,9 @@ fn copy_image_entries_to_host(
             let children = fs
                 .list_directory(entry)
                 .with_context(|| format!("listing '{}'", entry.name))?;
-            count += copy_image_entries_to_host(fs, &children, &sub)?;
+            count += copy_image_entries_to_host(fs, &children, &sub, fork_mode)?;
         } else if entry.is_file() {
-            let out = dest_dir.join(&entry.name);
-            let mut f = std::fs::File::create(&out)
-                .with_context(|| format!("creating {}", out.display()))?;
-            fs.write_file_to(entry, &mut f)
+            export_file_with_fork(fs, entry, dest_dir, &safe_name(entry), fork_mode)
                 .with_context(|| format!("extracting '{}'", entry.name))?;
             count += 1;
         }
@@ -377,6 +381,113 @@ pub fn spawn_apply(session: BrowseSession, edits: Vec<StagedEdit>) -> Arc<Mutex<
     let status_thread = Arc::clone(&status);
     thread::spawn(move || {
         let result = apply_edits(&session, &edits);
+        if let Ok(mut g) = status_thread.lock() {
+            if let Err(e) = result {
+                g.error = Some(format!("{e:#}"));
+            }
+            g.finished = true;
+        }
+    });
+    status
+}
+
+/// A 4-byte HFS OSType as the string the daemon's `StageUpload` carries. Lossy
+/// for high-bit bytes, matching the CLI `put` path's text round-trip.
+#[cfg(feature = "remote")]
+fn os4_to_string(code: &[u8; 4]) -> String {
+    String::from_utf8_lossy(code).into_owned()
+}
+
+/// Apply a remote destination pane's staged **copy** edits over the Family-F
+/// write path (`OpenSession` → `StageUpload` / `StageMkdir` → `Apply`).
+///
+/// A remote pane has no local [`BrowseSession`]: the daemon holds the image open
+/// and resolves the partition server-side, so this connects a fresh
+/// `RemoteSession` bound to the same `(image_path, partition)` the pane is
+/// browsing. Only `AddFile` / `CreateDirectory` are carried — the protocol has
+/// no delete / rename / metadata verbs yet, and `StageUpload` sends the data
+/// fork plus HFS type/creator only (no resource fork, no exact source dates).
+/// The caller rejects a queue containing any other edit before spawning; this
+/// re-checks defensively and, on any staging error, closes the session so
+/// nothing is half-applied (Apply is what commits).
+#[cfg(feature = "remote")]
+fn remote_apply(
+    addr: &str,
+    image_path: &str,
+    partition: Option<u32>,
+    edits: &[StagedEdit],
+) -> Result<()> {
+    use crate::remote::RemoteSession;
+    let mut session = RemoteSession::connect(addr).context("connecting to the daemon")?;
+    let sid = session
+        .open_session(image_path, partition)
+        .context("opening a remote write session")?;
+    let staged = (|| -> Result<()> {
+        for edit in edits {
+            match edit {
+                StagedEdit::AddFile {
+                    parent,
+                    name,
+                    host_path,
+                    resource_fork,
+                    hfs_type_override,
+                    hfs_creator_override,
+                    ..
+                } => {
+                    let type_code = hfs_type_override
+                        .as_ref()
+                        .or_else(|| resource_fork.as_ref().and_then(|r| r.type_code.as_ref()))
+                        .map(os4_to_string);
+                    let creator_code = hfs_creator_override
+                        .as_ref()
+                        .or_else(|| resource_fork.as_ref().and_then(|r| r.creator_code.as_ref()))
+                        .map(os4_to_string);
+                    session
+                        .stage_upload(
+                            sid,
+                            &parent.path,
+                            name,
+                            host_path,
+                            false,
+                            type_code,
+                            creator_code,
+                        )
+                        .with_context(|| format!("uploading {name}"))?;
+                }
+                StagedEdit::CreateDirectory { parent, name } => {
+                    session
+                        .stage_mkdir(sid, &parent.path, name)
+                        .with_context(|| format!("creating directory {name}"))?;
+                }
+                _ => {
+                    return Err(anyhow::anyhow!(
+                        "remote copy carries files and folders only; other edits \
+                         (delete / rename / metadata) can't be applied over the wire yet"
+                    ));
+                }
+            }
+        }
+        session.apply(sid).context("applying the remote edits")?;
+        Ok(())
+    })();
+    // Always release the session + staging blobs, even on error.
+    let _ = session.close_session(sid);
+    staged
+}
+
+/// Run [`remote_apply`] on a worker thread, reusing [`ApplyStatus`] so the pane
+/// polls it exactly like a local apply.
+#[cfg(feature = "remote")]
+pub fn spawn_remote_apply(
+    addr: String,
+    image_path: String,
+    partition: Option<u32>,
+    edits: Vec<StagedEdit>,
+) -> Arc<Mutex<ApplyStatus>> {
+    let status = Arc::new(Mutex::new(ApplyStatus::default()));
+    let status_thread = Arc::clone(&status);
+    thread::spawn(move || {
+        let result = remote_apply(&addr, &image_path, partition, &edits);
         if let Ok(mut g) = status_thread.lock() {
             if let Err(e) = result {
                 g.error = Some(format!("{e:#}"));
@@ -728,7 +839,13 @@ mod tests {
         let entries = fs.list_directory(&root).unwrap();
 
         let out = tempfile::tempdir().unwrap();
-        let n = copy_image_entries_to_host(fs.as_mut(), &entries, out.path()).expect("extract");
+        let n = copy_image_entries_to_host(
+            fs.as_mut(),
+            &entries,
+            out.path(),
+            ResourceForkMode::DataForkOnly,
+        )
+        .expect("extract");
         assert_eq!(n, 2);
         assert_eq!(std::fs::read(out.path().join("A.TXT")).unwrap(), b"hello");
         assert_eq!(

--- a/src/remote/client.rs
+++ b/src/remote/client.rs
@@ -138,6 +138,30 @@ impl RemoteSession {
         }
     }
 
+    /// Stream a single file's **resource fork** bytes into `sink`, returning the
+    /// byte count (0 for a file with no resource fork). Lets a remote export
+    /// preserve Mac forks.
+    pub fn read_resource_fork(
+        &mut self,
+        handle: u64,
+        path: &str,
+        sink: &mut dyn Write,
+    ) -> Result<u64> {
+        write_control(
+            &mut self.writer,
+            &Request::ReadResourceFork {
+                handle,
+                path: path.to_string(),
+            },
+        )?;
+        match self.read_response()? {
+            Response::FileBegin { .. } => read_chunks(&mut self.reader, sink)
+                .map_err(|e| anyhow!("reading resource fork of {path}: {e}")),
+            Response::Error { message } => bail!("read resource fork of {path}: {message}"),
+            other => bail!("unexpected reply to ReadResourceFork: {other:?}"),
+        }
+    }
+
     /// Drop an opened-image handle on the daemon (the read-side `Close`). The
     /// daemon's handle table is per-connection, so closing a handle frees its
     /// open image without affecting other handles on the same session.

--- a/src/remote/connection.rs
+++ b/src/remote/connection.rs
@@ -89,6 +89,17 @@ impl RemoteConnection {
         self.session.read_file(handle, path, sink)
     }
 
+    /// Stream one file's resource-fork bytes (from inside an opened image) into
+    /// `sink`. Returns 0 for a file with no resource fork.
+    pub fn read_resource_fork(
+        &mut self,
+        handle: u64,
+        path: &str,
+        sink: &mut dyn Write,
+    ) -> Result<u64> {
+        self.session.read_resource_fork(handle, path, sink)
+    }
+
     // --- host filesystem (the file browser) --------------------------------
 
     /// Classify a host path on the daemon: `(exists, is_dir)`.

--- a/src/remote/fs.rs
+++ b/src/remote/fs.rs
@@ -146,6 +146,19 @@ impl Filesystem for RemoteFilesystem {
             .map_err(wire_err)
     }
 
+    fn write_resource_fork_to(
+        &mut self,
+        entry: &FileEntry,
+        writer: &mut dyn Write,
+    ) -> Result<u64, FilesystemError> {
+        // The daemon reads the fork off its open image and streams it back, so a
+        // remote export preserves Mac resource forks. Empty stream (0) when the
+        // file has none.
+        lock_conn(&self.conn)?
+            .read_resource_fork(self.handle, &entry.path, writer)
+            .map_err(wire_err)
+    }
+
     fn volume_label(&self) -> Option<&str> {
         self.volume_label.as_deref()
     }
@@ -310,6 +323,7 @@ fn wire_to_entry(w: WireEntry) -> FileEntry {
         creator_code,
         prodos_file_type,
         symlink_target,
+        resource_fork_size,
     } = w;
     let mut e = match kind {
         WireKind::Dir => FileEntry::new_directory(name, path, 0),
@@ -322,6 +336,7 @@ fn wire_to_entry(w: WireEntry) -> FileEntry {
     e.type_code = type_code;
     e.creator_code = creator_code;
     e.prodos_file_type = prodos_file_type;
+    e.resource_fork_size = resource_fork_size;
     e
 }
 
@@ -340,6 +355,7 @@ mod tests {
             creator_code: None,
             prodos_file_type: None,
             symlink_target: None,
+            resource_fork_size: None,
         });
         assert!(dir.is_directory());
         assert_eq!(dir.path, "/SUB");
@@ -353,11 +369,13 @@ mod tests {
             creator_code: Some(*b"ttxt"),
             prodos_file_type: None,
             symlink_target: None,
+            resource_fork_size: Some(567),
         });
         assert!(!file.is_directory());
         assert_eq!(file.size, 1234);
         assert_eq!(file.type_code, Some(*b"TEXT"));
         assert_eq!(file.creator_code, Some(*b"ttxt"));
+        assert_eq!(file.resource_fork_size, Some(567), "rsrc size round-trips");
 
         let link = wire_to_entry(WireEntry {
             name: "LN".into(),
@@ -368,6 +386,7 @@ mod tests {
             creator_code: None,
             prodos_file_type: None,
             symlink_target: Some("/target".into()),
+            resource_fork_size: None,
         });
         assert_eq!(link.symlink_target.as_deref(), Some("/target"));
     }

--- a/src/remote/protocol.rs
+++ b/src/remote/protocol.rs
@@ -91,6 +91,10 @@ pub enum Request {
     ListDir { handle: u64, path: String },
     /// Stream one file's bytes (reply: `FileBegin`, then a chunk stream).
     ReadFile { handle: u64, path: String },
+    /// Stream one file's **resource fork** bytes (reply: `FileBegin` with the
+    /// resource-fork size, then a chunk stream). Empty stream for a file with no
+    /// resource fork. Lets a remote export preserve Mac forks.
+    ReadResourceFork { handle: u64, path: String },
     /// Drop an opened-image handle.
     Close { handle: u64 },
 
@@ -306,6 +310,11 @@ pub struct WireEntry {
     /// ProDOS 1-byte file type (ProDOS has no OSType). `None` elsewhere.
     pub prodos_file_type: Option<u8>,
     pub symlink_target: Option<String>,
+    /// Resource-fork size in bytes, so a remote browse shows the RSRC column.
+    /// `#[serde(default)]` keeps older peers (which never send it) parseable.
+    /// `None`/`Some(0)` means no resource fork.
+    #[serde(default)]
+    pub resource_fork_size: Option<u64>,
 }
 
 /// Entry kind over the wire — mirrors [`crate::fs::entry::EntryType`].
@@ -336,6 +345,7 @@ impl WireEntry {
             creator_code: e.creator_code,
             prodos_file_type: e.prodos_file_type,
             symlink_target: e.symlink_target.clone(),
+            resource_fork_size: e.resource_fork_size,
         }
     }
 

--- a/src/remote/server.rs
+++ b/src/remote/server.rs
@@ -877,6 +877,27 @@ fn handle_conn(stream: TcpStream, root: &Path, staging_dir: Option<&Path>) -> Re
                 },
             },
 
+            Request::ReadResourceFork { handle, path } => match handles.get_mut(&handle) {
+                None => reply_err(&mut writer, format!("no such handle {handle}"))?,
+                Some(fs) => match resolve_path(&mut **fs, &path) {
+                    Err(e) => reply_err(&mut writer, format!("{e:#}"))?,
+                    Ok(entry) if entry.is_directory() => {
+                        reply_err(&mut writer, format!("{path} is a directory"))?
+                    }
+                    Ok(entry) => {
+                        // Same commit-to-the-stream contract as ReadFile. Size is
+                        // the resource-fork size (0 = no fork → an empty stream).
+                        let size = entry.resource_fork_size.unwrap_or(0);
+                        write_control(&mut writer, &Response::FileBegin { size })?;
+                        let mut cw = ChunkWriter::new(&mut writer);
+                        if let Err(e) = fs.write_resource_fork_to(&entry, &mut cw) {
+                            return Err(anyhow!("write_resource_fork_to({path}): {e}"));
+                        }
+                        cw.finish()?;
+                    }
+                },
+            },
+
             Request::Close { handle } => {
                 handles.remove(&handle);
                 write_control(&mut writer, &Response::Ok)?;
@@ -1846,6 +1867,7 @@ fn list_host_dir(root: &Path, rel: &str) -> Result<Vec<WireEntry>> {
             creator_code: None,
             prodos_file_type: None,
             symlink_target: None,
+            resource_fork_size: None,
         });
     }
     out.sort_by(|a, b| a.name.cmp(&b.name));

--- a/src/update.rs
+++ b/src/update.rs
@@ -30,6 +30,88 @@ pub struct UpdateConfig {
     /// handful of entries.
     #[serde(default)]
     pub recent_daemon_addrs: Vec<String>,
+    /// Per-mode recent-files history for the GUI "Recent" quick-pick lists
+    /// (Inspect, Restore, Optical, Archives, Commander). Each list is
+    /// newest-first, deduped, and capped; see [`RecentFiles`].
+    #[serde(default)]
+    pub recent_files: RecentFiles,
+}
+
+/// Per-mode most-recently-used file/folder history for the GUI's "Recent"
+/// pickers. Each mode keeps its own list so, e.g., disc images opened on the
+/// Optical tab don't clutter the Inspect tab's history. Lists are newest-first,
+/// deduped, and capped to [`RecentFiles::CAP`]; paths are stored as display
+/// strings. Every field is `#[serde(default)]` so a config.json written by an
+/// older build (no `recent_files` key, or missing a mode) still parses.
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+pub struct RecentFiles {
+    #[serde(default)]
+    pub inspect: Vec<String>,
+    #[serde(default)]
+    pub restore: Vec<String>,
+    #[serde(default)]
+    pub optical: Vec<String>,
+    #[serde(default)]
+    pub archives: Vec<String>,
+    #[serde(default)]
+    pub commander: Vec<String>,
+    #[serde(default)]
+    pub backup: Vec<String>,
+}
+
+impl RecentFiles {
+    /// Maximum entries retained per mode.
+    pub const CAP: usize = 10;
+
+    /// The (newest-first) recent list for `mode`.
+    pub fn list(&self, mode: RecentMode) -> &[String] {
+        match mode {
+            RecentMode::Inspect => &self.inspect,
+            RecentMode::Restore => &self.restore,
+            RecentMode::Optical => &self.optical,
+            RecentMode::Archives => &self.archives,
+            RecentMode::Commander => &self.commander,
+            RecentMode::Backup => &self.backup,
+        }
+    }
+
+    fn list_mut(&mut self, mode: RecentMode) -> &mut Vec<String> {
+        match mode {
+            RecentMode::Inspect => &mut self.inspect,
+            RecentMode::Restore => &mut self.restore,
+            RecentMode::Optical => &mut self.optical,
+            RecentMode::Archives => &mut self.archives,
+            RecentMode::Commander => &mut self.commander,
+            RecentMode::Backup => &mut self.backup,
+        }
+    }
+
+    /// Total remembered entries across every mode. Drives the Settings "Clear
+    /// Recent Files" affordance (count shown, button disabled when zero).
+    pub fn total(&self) -> usize {
+        self.inspect.len()
+            + self.restore.len()
+            + self.optical.len()
+            + self.archives.len()
+            + self.commander.len()
+            + self.backup.len()
+    }
+
+    /// Forget every mode's recent list.
+    pub fn clear(&mut self) {
+        *self = Self::default();
+    }
+}
+
+/// Which GUI mode a recent-files list belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecentMode {
+    Inspect,
+    Restore,
+    Optical,
+    Archives,
+    Commander,
+    Backup,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -96,6 +178,7 @@ impl Default for UpdateConfig {
             file_associations_enabled: false,
             assoc_registered_version: None,
             recent_daemon_addrs: Vec::new(),
+            recent_files: RecentFiles::default(),
         }
     }
 }
@@ -179,6 +262,20 @@ impl UpdateConfig {
         self.recent_daemon_addrs.retain(|a| a != addr);
         self.recent_daemon_addrs.insert(0, addr.to_string());
         self.recent_daemon_addrs.truncate(8);
+    }
+
+    /// Record a successfully-opened path in the per-mode recent-files MRU
+    /// (dedup, newest first, capped to [`RecentFiles::CAP`]). No-op for a blank
+    /// path.
+    pub fn remember_file(&mut self, mode: RecentMode, path: &str) {
+        let path = path.trim();
+        if path.is_empty() {
+            return;
+        }
+        let list = self.recent_files.list_mut(mode);
+        list.retain(|p| p != path);
+        list.insert(0, path.to_string());
+        list.truncate(RecentFiles::CAP);
     }
 }
 
@@ -404,5 +501,55 @@ mod tests {
         }
         assert_eq!(cfg.recent_daemon_addrs.len(), 8);
         assert_eq!(cfg.recent_daemon_addrs[0], "h:9");
+    }
+
+    #[test]
+    fn remember_file_is_per_mode_mru_deduped_capped() {
+        let mut cfg = UpdateConfig::default();
+        cfg.remember_file(RecentMode::Inspect, "/a.img");
+        cfg.remember_file(RecentMode::Inspect, "/b.img");
+        // Re-using a path moves it to the front (no duplicate).
+        cfg.remember_file(RecentMode::Inspect, "/a.img");
+        assert_eq!(
+            cfg.recent_files.list(RecentMode::Inspect),
+            ["/a.img", "/b.img"]
+        );
+        // Lists are per-mode: Optical is independent of Inspect.
+        cfg.remember_file(RecentMode::Optical, "/disc.iso");
+        assert_eq!(cfg.recent_files.list(RecentMode::Optical), ["/disc.iso"]);
+        assert_eq!(cfg.recent_files.list(RecentMode::Inspect).len(), 2);
+        // Blank / whitespace is ignored.
+        cfg.remember_file(RecentMode::Inspect, "   ");
+        assert_eq!(cfg.recent_files.list(RecentMode::Inspect).len(), 2);
+        // Capped at CAP, newest first.
+        for i in 0..(RecentFiles::CAP + 5) {
+            cfg.remember_file(RecentMode::Inspect, &format!("/f{i}.img"));
+        }
+        assert_eq!(
+            cfg.recent_files.list(RecentMode::Inspect).len(),
+            RecentFiles::CAP
+        );
+        assert_eq!(
+            cfg.recent_files.list(RecentMode::Inspect)[0],
+            format!("/f{}.img", RecentFiles::CAP + 4)
+        );
+    }
+
+    #[test]
+    fn recent_files_total_and_clear() {
+        let mut cfg = UpdateConfig::default();
+        assert_eq!(cfg.recent_files.total(), 0);
+        cfg.remember_file(RecentMode::Inspect, "/a.img");
+        cfg.remember_file(RecentMode::Inspect, "/b.img");
+        cfg.remember_file(RecentMode::Optical, "/disc.iso");
+        cfg.remember_file(RecentMode::Commander, "/c.hda");
+        // total() sums across every mode.
+        assert_eq!(cfg.recent_files.total(), 4);
+        // clear() forgets every mode at once.
+        cfg.recent_files.clear();
+        assert_eq!(cfg.recent_files.total(), 0);
+        assert!(cfg.recent_files.list(RecentMode::Inspect).is_empty());
+        assert!(cfg.recent_files.list(RecentMode::Optical).is_empty());
+        assert!(cfg.recent_files.list(RecentMode::Commander).is_empty());
     }
 }

--- a/tests/commander_archive.rs
+++ b/tests/commander_archive.rs
@@ -1,0 +1,48 @@
+//! Commander opens a Mac archive in-pane: `commander_descend::open_archive`
+//! (what the pane's `load_archive` calls) decodes an archive into a browsable,
+//! read-only `Filesystem` carrying both forks + type/creator.
+
+use rusty_backup::fs::binhex::{build_binhex, BinHexFile};
+use rusty_backup::model::commander_descend::open_archive;
+
+#[test]
+fn open_archive_browses_a_binhex_file_with_both_forks() {
+    // Build a BinHex (.hqx) archive in memory holding one file with both forks.
+    let data = b"hello data fork from the archive";
+    let rsrc = b"RSRC fork bytes inside the archive";
+    let hqx = build_binhex(&BinHexFile {
+        name: "Note".into(),
+        type_code: *b"TEXT",
+        creator_code: *b"ttxt",
+        flags: 0,
+        data_fork: data.to_vec(),
+        resource_fork: rsrc.to_vec(),
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("note.hqx");
+    std::fs::write(&path, hqx.as_bytes()).unwrap();
+
+    // The exact call the Commander pane uses to open an archive as a source.
+    let mut fs = open_archive(&path, Some("note.hqx".into())).unwrap();
+    let root = fs.root().unwrap();
+    let entries = fs.list_directory(&root).unwrap();
+    let note = entries
+        .iter()
+        .find(|e| e.is_file())
+        .expect("archive lists its file");
+    assert_eq!(note.type_code, Some(*b"TEXT"));
+    assert_eq!(note.creator_code, Some(*b"ttxt"));
+    assert_eq!(
+        note.resource_fork_size,
+        Some(rsrc.len() as u64),
+        "the RSRC column has a size for archive entries"
+    );
+
+    // Both forks read back byte-exact (this is what copy-out / export use).
+    let mut got_data = Vec::new();
+    fs.write_file_to(note, &mut got_data).unwrap();
+    assert_eq!(got_data, data, "data fork byte-exact");
+    let mut got_rsrc = Vec::new();
+    fs.write_resource_fork_to(note, &mut got_rsrc).unwrap();
+    assert_eq!(got_rsrc, rsrc, "resource fork byte-exact");
+}

--- a/tests/fork_export.rs
+++ b/tests/fork_export.rs
@@ -1,0 +1,97 @@
+//! Fork-preserving single-file export: MacBinary (.bin) and AppleDouble
+//! (`._name` sidecar) output from an HFS file carrying a resource fork. Guards
+//! `fs::fork_export::export_file_with_fork`, which Commander's copy/export-to-
+//! host now uses.
+
+use rusty_backup::cli::resolve::resolve_partition_ro;
+use rusty_backup::fs::filesystem::{CreateFileOptions, ResourceForkSource};
+use rusty_backup::fs::fork_export::export_file_with_fork;
+use rusty_backup::fs::resource_fork::ResourceForkMode;
+use rusty_backup::fs::{hfs, open_editable_filesystem, open_filesystem};
+
+/// Build a bare classic-HFS image with one file that has both forks.
+fn make_hfs_with_fork(path: &std::path::Path, name: &str, data: &[u8], rsrc: &[u8]) {
+    std::fs::write(
+        path,
+        hfs::create_blank_hfs(4 * 1024 * 1024, 512, "MACVOL").unwrap(),
+    )
+    .unwrap();
+    let (file, ctx, commit) = rusty_backup::cli::resolve::resolve_partition_rw(path, None).unwrap();
+    let mut efs =
+        open_editable_filesystem(file, ctx.offset, ctx.type_byte, ctx.type_string.as_deref())
+            .unwrap();
+    let parent = efs.root().unwrap();
+    let opts = CreateFileOptions {
+        resource_fork: Some(ResourceForkSource::Data(rsrc.to_vec())),
+        ..Default::default()
+    };
+    let mut d = data;
+    efs.create_file(&parent, name, &mut d, data.len() as u64, &opts)
+        .unwrap();
+    efs.sync_metadata().unwrap();
+    drop(efs);
+    commit.commit().unwrap();
+}
+
+#[test]
+fn export_macbinary_and_appledouble_preserve_the_resource_fork() {
+    let dir = tempfile::tempdir().unwrap();
+    let img = dir.path().join("mac.img");
+    let data = b"data fork contents for export";
+    let rsrc = b"the resource fork payload to preserve";
+    make_hfs_with_fork(&img, "FORKED.BIN", data, rsrc);
+
+    let (file, ctx) = resolve_partition_ro(&img, None).unwrap();
+    let mut fs =
+        open_filesystem(file, ctx.offset, ctx.type_byte, ctx.type_string.as_deref()).unwrap();
+    let root = fs.root().unwrap();
+    let forked = fs
+        .list_directory(&root)
+        .unwrap()
+        .into_iter()
+        .find(|e| e.name.eq_ignore_ascii_case("FORKED.BIN"))
+        .expect("forked file present");
+    assert_eq!(forked.resource_fork_size, Some(rsrc.len() as u64));
+
+    let out = tempfile::tempdir().unwrap();
+
+    // MacBinary: one self-contained .bin holding both forks (rsrc verbatim).
+    let name = rusty_backup::fs::fork_export::safe_name(&forked);
+    export_file_with_fork(
+        fs.as_mut(),
+        &forked,
+        out.path(),
+        &name,
+        ResourceForkMode::MacBinary,
+    )
+    .unwrap();
+    let bin = std::fs::read(out.path().join("FORKED.BIN.bin")).unwrap();
+    assert!(
+        bin.len() >= 128 + data.len() + rsrc.len(),
+        "MacBinary = 128B header + both forks"
+    );
+    assert!(
+        bin.windows(rsrc.len()).any(|w| w == rsrc),
+        "resource fork bytes present in the MacBinary"
+    );
+
+    // AppleDouble: data fork under the plain name + a `._name` rsrc sidecar.
+    export_file_with_fork(
+        fs.as_mut(),
+        &forked,
+        out.path(),
+        &name,
+        ResourceForkMode::AppleDouble,
+    )
+    .unwrap();
+    assert_eq!(
+        std::fs::read(out.path().join("FORKED.BIN")).unwrap(),
+        data,
+        "AppleDouble writes the data fork under the plain name"
+    );
+    let ad = std::fs::read(out.path().join("._FORKED.BIN")).unwrap();
+    assert!(
+        ad.windows(rsrc.len()).any(|w| w == rsrc),
+        "resource fork bytes present in the AppleDouble sidecar"
+    );
+}

--- a/tests/remote_filesystem.rs
+++ b/tests/remote_filesystem.rs
@@ -9,8 +9,8 @@ use std::net::TcpListener;
 use std::sync::Arc;
 
 use rusty_backup::cli::resolve::resolve_partition_rw;
-use rusty_backup::fs::filesystem::{CreateFileOptions, Filesystem};
-use rusty_backup::fs::{fat, open_editable_filesystem};
+use rusty_backup::fs::filesystem::{CreateFileOptions, Filesystem, ResourceForkSource};
+use rusty_backup::fs::{fat, hfs, open_editable_filesystem};
 use rusty_backup::remote::{serve_on, RemoteConnection, RemoteFilesystem, RemoteHostFilesystem};
 
 /// Build an 8 MiB FAT image at `path` with a single file `file_name` full of
@@ -134,6 +134,163 @@ fn remote_filesystem_browses_and_reads_over_loopback() {
     let mut got = Vec::new();
     host_fs.write_file_to(notes, &mut got).unwrap();
     assert_eq!(got, note, "host-file read must be byte-exact");
+}
+
+/// Build a bare classic-HFS image (superfloppy, no partition table) with one
+/// file carrying both a data fork and a resource fork.
+fn make_hfs_image_with_fork(
+    path: &std::path::Path,
+    vol: &str,
+    file_name: &str,
+    data: &[u8],
+    rsrc: &[u8],
+) {
+    std::fs::write(
+        path,
+        hfs::create_blank_hfs(4 * 1024 * 1024, 512, vol).unwrap(),
+    )
+    .unwrap();
+    let (file, ctx, commit) = resolve_partition_rw(path, None).unwrap();
+    let mut efs =
+        open_editable_filesystem(file, ctx.offset, ctx.type_byte, ctx.type_string.as_deref())
+            .unwrap();
+    let parent = efs.root().unwrap();
+    let opts = CreateFileOptions {
+        resource_fork: Some(ResourceForkSource::Data(rsrc.to_vec())),
+        ..Default::default()
+    };
+    let mut d = data;
+    efs.create_file(&parent, file_name, &mut d, data.len() as u64, &opts)
+        .unwrap();
+    efs.sync_metadata().unwrap();
+    drop(efs);
+    commit.commit().unwrap();
+}
+
+/// End-to-end for the two resource-fork fixes: a remote browse carries the RSRC
+/// **size** over the wire (the `WireEntry` field), and the new `ReadResourceFork`
+/// op streams the fork **bytes** back byte-exact — what Commander's fork-preserving
+/// export needs on the remote side.
+#[test]
+fn family_f_reads_resource_fork_and_size_over_wire() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    let img = root.join("mac.img");
+    let data = b"data fork contents for the forked file";
+    let rsrc = b"RESOURCE FORK BYTES sent across the wire";
+    make_hfs_image_with_fork(&img, "MACVOL", "FORKED.BIN", data, rsrc);
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    let serve_root = root.clone();
+    std::thread::spawn(move || {
+        let _ = serve_on(listener, serve_root, None);
+    });
+
+    let (mut rfs, root_entry, _children) = RemoteFilesystem::open(&addr, "/mac.img", None).unwrap();
+    let listed = rfs.list_directory(&root_entry).unwrap();
+    let forked = listed
+        .iter()
+        .find(|e| e.name.eq_ignore_ascii_case("FORKED.BIN"))
+        .expect("forked file present in remote listing");
+
+    // Fix 1: the resource-fork SIZE travels over the wire (was dropped before).
+    assert_eq!(
+        forked.resource_fork_size,
+        Some(rsrc.len() as u64),
+        "resource-fork size must survive the wire round trip"
+    );
+
+    // Fix 2: the resource-fork BYTES stream back byte-exact via ReadResourceFork.
+    let mut got_rsrc = Vec::new();
+    rfs.write_resource_fork_to(forked, &mut got_rsrc).unwrap();
+    assert_eq!(
+        got_rsrc, rsrc,
+        "resource fork bytes byte-exact over the wire"
+    );
+
+    // The data fork still reads back correctly alongside it.
+    let mut got_data = Vec::new();
+    rfs.write_file_to(forked, &mut got_data).unwrap();
+    assert_eq!(got_data, data, "data fork byte-exact over the wire");
+}
+
+/// End-to-end for the Family F **write** path that Commander's local→remote copy
+/// drives: stage a file upload plus a directory into a remote FAT image, apply,
+/// and confirm both land (browsed back over the read path). Mirrors
+/// `commander_ops::remote_apply`'s `OpenSession` → `StageUpload` / `StageMkdir`
+/// → `Apply` sequence, so it guards the transport Commander now depends on.
+#[test]
+fn family_f_write_stages_file_and_dir_into_remote_image() {
+    use rusty_backup::remote::RemoteSession;
+
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    // A remote FAT image to copy INTO (starts with one seed file).
+    make_fat_image(&root.join("dest.img"), "DESTVOL", "SEED.BIN", 0x01, 512);
+
+    // Uploads land in a staging dir on the daemon before Apply commits them.
+    let staging_tmp = tempfile::tempdir().unwrap();
+    let staging = staging_tmp.path().to_path_buf();
+
+    // A local host file to upload — the blob a staged copy would reference.
+    let host_tmp = tempfile::tempdir().unwrap();
+    let host_file = host_tmp.path().join("payload.bin");
+    let payload = vec![0xABu8; 3000];
+    std::fs::write(&host_file, &payload).unwrap();
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    let serve_root = root.clone();
+    let serve_staging = staging.clone();
+    std::thread::spawn(move || {
+        let _ = serve_on(listener, serve_root, Some(serve_staging));
+    });
+
+    // --- drive the Family F write path (exactly what remote_apply does) ---
+    {
+        let mut session = RemoteSession::connect(&addr).unwrap();
+        let sid = session.open_session("/dest.img", None).unwrap();
+        session.stage_mkdir(sid, "/", "SUBDIR").unwrap();
+        session
+            .stage_upload(
+                sid,
+                "/",
+                "COPIED.BIN",
+                &host_file,
+                false,
+                Some("TEXT".to_string()),
+                Some("ttxt".to_string()),
+            )
+            .unwrap();
+        let n = session.apply(sid).unwrap();
+        assert_eq!(n, 2, "two staged edits applied (mkdir + upload)");
+        session.close_session(sid).unwrap();
+    }
+
+    // --- verify over the read path: a FRESH open (new daemon handle) sees the
+    // committed write, which is why the pane re-opens the image after apply ---
+    let (mut rfs, root_entry, _children) =
+        RemoteFilesystem::open(&addr, "/dest.img", None).unwrap();
+    let listed = rfs.list_directory(&root_entry).unwrap();
+    let names: Vec<&str> = listed.iter().map(|e| e.name.as_str()).collect();
+    assert!(
+        names.iter().any(|n| n.eq_ignore_ascii_case("COPIED.BIN")),
+        "uploaded file present after apply: {names:?}"
+    );
+    assert!(
+        names.iter().any(|n| n.eq_ignore_ascii_case("SUBDIR")),
+        "created directory present after apply: {names:?}"
+    );
+
+    // The uploaded file's bytes are byte-exact.
+    let copied = listed
+        .iter()
+        .find(|e| e.name.eq_ignore_ascii_case("COPIED.BIN"))
+        .unwrap();
+    let mut got = Vec::new();
+    rfs.write_file_to(copied, &mut got).unwrap();
+    assert_eq!(got, payload, "uploaded bytes are byte-exact");
 }
 
 /// Proves the core of "switch images without reconnecting": two images opened


### PR DESCRIPTION
## Summary

A UI-focused branch that adds a **recent-files system across every source picker**, fixes a long-standing dropdown-sizing problem, and lands prior remote-transfer / resource-fork / Commander work that was pending on this branch.

## Recent files

- Per-mode recent-files MRU persisted in `config.json` — Inspect, Restore, Optical, Archives, Commander, and a new **Backup** mode.
- **Fixed-slot rendering** for the recent lists (constant row count). This sidesteps a known egui bug ([emilk/egui#5225](https://github.com/emilk/egui/issues/5225) / [#5138](https://github.com/emilk/egui/issues/5138)) where a ComboBox popup caches its height the first time it opens and never regrows — so newly-added recents were clipped until a mouse-move forced a repaint. Inspect / Optical / Backup draw 5 fixed slots (newest fill them, rest are dim placeholders); popup max-height is now window-aware (`content_rect`) instead of a fixed 400px cap.
- **Backup tab** gains recents end-to-end: records on every image open (picker / drag-drop / re-pick), with a "Recent…" dropdown beside the Source combo.
- **Settings → "Clear Recent Files (N)"** wipes every mode's list (both `config.json` and the in-memory mirror each tab / Commander pane holds) and reports the count.
- Inspect source combo reverted to a plain fixed width (an earlier adaptive-width experiment looked awkward).

## Also included (prior work on this branch)

- **Remote copy / backup / browse** over `rb-cli serve` (`src/remote/*`, `model/commander_ops`, `tests/remote_filesystem`).
- **Shared resource-fork export** (`src/fs/fork_export.rs`) — `browse_view` and Commander route through it (`tests/fork_export`).
- **Commander archive-in-pane** browsing (`tests/commander_archive`).
- Drag-and-drop routes to the active tab / Commander pane.

## Testing

- `cargo build` and `cargo clippy` clean; **full test suite green (18 suites, 0 failures)**, plus a new `update::recent_files_total_and_clear` unit test.
- Interactive GUI bits (dropdown sizing, Clear Recent Files, Backup recents) compile + are unit-tested where applicable — a manual GUI pass is still recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
