### PR TITLE
feat(commander): Export-as engine + wrapper File Info, off-thread wrapper open, read-only pane badges

### DIFF
--- a/src/fs/export_selection.rs
+++ b/src/fs/export_selection.rs
@@ -46,24 +46,32 @@ pub enum ExportFormat {
     TarGz,
     /// A single zstd-compressed `.tar.zst`.
     TarZstd,
+    /// One BinHex 4.0 `.hqx` text file per file (both forks + Finder info),
+    /// into a mirrored folder tree.
+    BinHex,
     /// A single `.zip`; Mac resource forks ride along as `__MACOSX/._name`
     /// AppleDouble members (the convention macOS itself uses).
     Zip,
     /// A single classic StuffIt `.sit`; forks + Finder type/creator native.
     StuffIt,
+    /// A single MacArchive `.mar`; forks + Finder type/creator native, same
+    /// input tree as StuffIt.
+    MacArchive,
 }
 
 impl ExportFormat {
     /// Every format, in menu order (folder outputs first, then archives).
-    pub const ALL: [ExportFormat; 8] = [
+    pub const ALL: [ExportFormat; 10] = [
         ExportFormat::LooseFiles,
         ExportFormat::GzipPerFile,
         ExportFormat::ZstdPerFile,
+        ExportFormat::BinHex,
         ExportFormat::Tar,
         ExportFormat::TarGz,
         ExportFormat::TarZstd,
         ExportFormat::Zip,
         ExportFormat::StuffIt,
+        ExportFormat::MacArchive,
     ];
 
     /// Short menu / dropdown label.
@@ -72,11 +80,13 @@ impl ExportFormat {
             ExportFormat::LooseFiles => "Loose files",
             ExportFormat::GzipPerFile => "Gzip each file (.gz)",
             ExportFormat::ZstdPerFile => "Zstd each file (.zst)",
+            ExportFormat::BinHex => "BinHex each file (.hqx)",
             ExportFormat::Tar => "Tar (.tar)",
             ExportFormat::TarGz => "Tar + gzip (.tar.gz)",
             ExportFormat::TarZstd => "Tar + zstd (.tar.zst)",
             ExportFormat::Zip => "Zip (.zip)",
             ExportFormat::StuffIt => "StuffIt (.sit)",
+            ExportFormat::MacArchive => "Mac Archive (.mar)",
         }
     }
 
@@ -90,6 +100,7 @@ impl ExportFormat {
                 | ExportFormat::TarZstd
                 | ExportFormat::Zip
                 | ExportFormat::StuffIt
+                | ExportFormat::MacArchive
         )
     }
 
@@ -101,6 +112,7 @@ impl ExportFormat {
             ExportFormat::TarZstd => Some("tar.zst"),
             ExportFormat::Zip => Some("zip"),
             ExportFormat::StuffIt => Some("sit"),
+            ExportFormat::MacArchive => Some("mar"),
             _ => None,
         }
     }
@@ -179,8 +191,15 @@ fn folder_recurse(
             }
             EntryType::File => {
                 match format {
-                    ExportFormat::LooseFiles => {
-                        export_file_with_fork(fs, e, dest_dir, &safe_name(e), fork_mode)
+                    // BinHex is a fixed fork container, independent of the loose
+                    // "Forks as:" choice.
+                    ExportFormat::LooseFiles | ExportFormat::BinHex => {
+                        let mode = if format == ExportFormat::BinHex {
+                            ResourceForkMode::BinHex
+                        } else {
+                            fork_mode
+                        };
+                        export_file_with_fork(fs, e, dest_dir, &safe_name(e), mode)
                             .with_context(|| format!("exporting '{}'", e.name))?;
                     }
                     ExportFormat::GzipPerFile | ExportFormat::ZstdPerFile => {
@@ -264,7 +283,9 @@ pub fn export_to_file(
             export_tar_file(fs, entries, out_path, format, progress)
         }
         ExportFormat::Zip => export_zip_file(fs, entries, out_path, progress, cancelled),
-        ExportFormat::StuffIt => export_sit_file(fs, entries, out_path, progress, cancelled),
+        ExportFormat::StuffIt | ExportFormat::MacArchive => {
+            export_mac_archive_file(fs, entries, out_path, format, progress, cancelled)
+        }
         _ => anyhow::bail!("{:?} is not a single-file format", format),
     }
 }
@@ -383,16 +404,27 @@ fn zip_recurse<W: Write + std::io::Seek>(
     Ok(())
 }
 
-fn export_sit_file(
+/// Build a `.sit` (StuffIt) or `.mar` (MacArchive) from the selection — both use
+/// the same [`StuffItInputNode`] tree, differing only in the container writer.
+fn export_mac_archive_file(
     fs: &mut dyn Filesystem,
     entries: &[FileEntry],
     out_path: &Path,
+    format: ExportFormat,
     progress: &Progress,
     cancelled: &Cancelled,
 ) -> Result<ExportSummary> {
     let mut summary = ExportSummary::default();
     let nodes = sit_nodes(fs, entries, progress, cancelled, &mut summary)?;
-    let bytes = build_archive_tree(&nodes, WriteMethod::Rle).context("building StuffIt archive")?;
+    let bytes = if format == ExportFormat::MacArchive {
+        let root = out_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("archive");
+        crate::macarchive::mar::build_archive(root, &nodes).context("building MacArchive (.mar)")?
+    } else {
+        build_archive_tree(&nodes, WriteMethod::Rle).context("building StuffIt archive")?
+    };
     std::fs::write(out_path, &bytes).with_context(|| format!("writing {}", out_path.display()))?;
     Ok(summary)
 }
@@ -628,6 +660,53 @@ mod tests {
             .iter()
             .find(|e| e.name == "HELLO.TXT")
             .expect("HELLO.TXT in sit");
+        let data =
+            crate::macarchive::stuffit::decompress_fork(&bytes, hello.data.as_ref().unwrap())
+                .unwrap();
+        assert_eq!(data, b"hello world");
+    }
+
+    #[test]
+    fn binhex_per_file_round_trips() {
+        let (mut fs, entries, _g) = fixture();
+        let out = tempfile::tempdir().unwrap();
+        export_to_folder(
+            &mut *fs,
+            &entries,
+            out.path(),
+            ExportFormat::BinHex,
+            ResourceForkMode::Native,
+            &noprog,
+            &never,
+        )
+        .unwrap();
+        let hqx = std::fs::read(out.path().join("HELLO.TXT.hqx")).unwrap();
+        let bh = crate::fs::binhex::parse_binhex(&hqx).unwrap();
+        assert_eq!(bh.data_fork, b"hello world");
+    }
+
+    #[test]
+    fn mac_archive_round_trips_through_parser() {
+        let (mut fs, entries, _g) = fixture();
+        let out = tempfile::tempdir().unwrap();
+        let path = out.path().join("out.mar");
+        let s = export_to_file(
+            &mut *fs,
+            &entries,
+            &path,
+            ExportFormat::MacArchive,
+            &noprog,
+            &never,
+        )
+        .unwrap();
+        assert_eq!(s.files, 3);
+        let raw = std::fs::read(&path).unwrap();
+        let (bytes, archive) = crate::macarchive::mar::parse(&raw).unwrap();
+        let hello = archive
+            .entries
+            .iter()
+            .find(|e| e.name == "HELLO.TXT")
+            .expect("HELLO.TXT in mar");
         let data =
             crate::macarchive::stuffit::decompress_fork(&bytes, hello.data.as_ref().unwrap())
                 .unwrap();

--- a/src/fs/export_selection.rs
+++ b/src/fs/export_selection.rs
@@ -1,0 +1,653 @@
+//! Export a Commander selection out of a source filesystem to the host in one
+//! of several output shapes — the engine behind the "Export as" control.
+//!
+//! Two destination shapes, chosen by [`ExportFormat::is_single_file`]:
+//! - **folder** outputs ([`export_to_folder`]) — loose files (resource forks in
+//!   the chosen [`ResourceForkMode`] container) or each file's data fork
+//!   individually gzip/zstd-compressed;
+//! - **single archive file** outputs ([`export_to_file`]) — a tar (optionally
+//!   gzip/zstd-compressed), a zip (data fork + AppleDouble `._name` sidecar for
+//!   Mac forks), or a classic StuffIt `.sit` (forks + type/creator native).
+//!
+//! All formats reuse dependencies already in the tree (`tar`, `zip`, `flate2`,
+//! the zstd backend selected by the `native-zstd` / `pure-zstd` feature, and the
+//! in-crate StuffIt writer), so nothing here is feature-gated.
+//!
+//! GUI-free and generic over the [`Filesystem`] trait, so it drives an image
+//! volume, a backup, an inline wrapper mount, or a remote image identically.
+
+use std::io::Write;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::fs::entry::{EntryType, FileEntry};
+use crate::fs::filesystem::Filesystem;
+use crate::fs::fork_export::{export_file_with_fork, safe_name};
+use crate::fs::resource_fork::{build_appledouble, MacFileDates, ResourceForkMode};
+use crate::fs::tar_export::{export_tar_multi, TarCompression, TarExportOptions};
+use crate::macarchive::stuffit::{build_archive_tree, StuffItInput, StuffItInputNode, WriteMethod};
+
+/// One user-selectable export output shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExportFormat {
+    /// Loose files into a folder; resource forks preserved via the chosen
+    /// [`ResourceForkMode`] container (MacBinary / BinHex / AppleDouble / …).
+    LooseFiles,
+    /// Each file's data fork gzip-compressed to `<name>.gz` in a mirrored
+    /// folder tree. Resource forks are not preserved (use loose / tar / sit).
+    GzipPerFile,
+    /// Each file's data fork zstd-compressed to `<name>.zst` in a mirrored
+    /// folder tree. Resource forks are not preserved.
+    ZstdPerFile,
+    /// A single uncompressed `.tar`. Data forks only; preserves *nix symlinks.
+    Tar,
+    /// A single gzip-compressed `.tar.gz`.
+    TarGz,
+    /// A single zstd-compressed `.tar.zst`.
+    TarZstd,
+    /// A single `.zip`; Mac resource forks ride along as `__MACOSX/._name`
+    /// AppleDouble members (the convention macOS itself uses).
+    Zip,
+    /// A single classic StuffIt `.sit`; forks + Finder type/creator native.
+    StuffIt,
+}
+
+impl ExportFormat {
+    /// Every format, in menu order (folder outputs first, then archives).
+    pub const ALL: [ExportFormat; 8] = [
+        ExportFormat::LooseFiles,
+        ExportFormat::GzipPerFile,
+        ExportFormat::ZstdPerFile,
+        ExportFormat::Tar,
+        ExportFormat::TarGz,
+        ExportFormat::TarZstd,
+        ExportFormat::Zip,
+        ExportFormat::StuffIt,
+    ];
+
+    /// Short menu / dropdown label.
+    pub fn label(self) -> &'static str {
+        match self {
+            ExportFormat::LooseFiles => "Loose files",
+            ExportFormat::GzipPerFile => "Gzip each file (.gz)",
+            ExportFormat::ZstdPerFile => "Zstd each file (.zst)",
+            ExportFormat::Tar => "Tar (.tar)",
+            ExportFormat::TarGz => "Tar + gzip (.tar.gz)",
+            ExportFormat::TarZstd => "Tar + zstd (.tar.zst)",
+            ExportFormat::Zip => "Zip (.zip)",
+            ExportFormat::StuffIt => "StuffIt (.sit)",
+        }
+    }
+
+    /// True when the output is a single archive *file* (the caller prompts for a
+    /// filename); false when it writes loose outputs into a *folder*.
+    pub fn is_single_file(self) -> bool {
+        matches!(
+            self,
+            ExportFormat::Tar
+                | ExportFormat::TarGz
+                | ExportFormat::TarZstd
+                | ExportFormat::Zip
+                | ExportFormat::StuffIt
+        )
+    }
+
+    /// The extension (no dot) for the single-file formats, for the save dialog.
+    pub fn file_extension(self) -> Option<&'static str> {
+        match self {
+            ExportFormat::Tar => Some("tar"),
+            ExportFormat::TarGz => Some("tar.gz"),
+            ExportFormat::TarZstd => Some("tar.zst"),
+            ExportFormat::Zip => Some("zip"),
+            ExportFormat::StuffIt => Some("sit"),
+            _ => None,
+        }
+    }
+}
+
+/// Tally of what an export produced, for the completion status line.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ExportSummary {
+    pub files: usize,
+    pub bytes: u64,
+}
+
+/// Progress callback: `(current_file_path, files_done, bytes_done)`, fired after
+/// each file. `bytes` counts source data-fork bytes read.
+pub type Progress<'a> = dyn Fn(&str, usize, u64) + 'a;
+
+/// Cancel gate: return `true` to abort at the next file boundary.
+pub type Cancelled<'a> = dyn Fn() -> bool + 'a;
+
+fn cancelled_err() -> anyhow::Error {
+    anyhow::anyhow!("export cancelled")
+}
+
+/// Export `entries` from `fs` as loose outputs into the directory `dest_dir`.
+/// Only [`ExportFormat::LooseFiles`] / [`GzipPerFile`](ExportFormat::GzipPerFile)
+/// / [`ZstdPerFile`](ExportFormat::ZstdPerFile) are valid here.
+pub fn export_to_folder(
+    fs: &mut dyn Filesystem,
+    entries: &[FileEntry],
+    dest_dir: &Path,
+    format: ExportFormat,
+    fork_mode: ResourceForkMode,
+    progress: &Progress,
+    cancelled: &Cancelled,
+) -> Result<ExportSummary> {
+    let mut summary = ExportSummary::default();
+    folder_recurse(
+        fs,
+        entries,
+        dest_dir,
+        format,
+        fork_mode,
+        progress,
+        cancelled,
+        &mut summary,
+    )?;
+    Ok(summary)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn folder_recurse(
+    fs: &mut dyn Filesystem,
+    entries: &[FileEntry],
+    dest_dir: &Path,
+    format: ExportFormat,
+    fork_mode: ResourceForkMode,
+    progress: &Progress,
+    cancelled: &Cancelled,
+    summary: &mut ExportSummary,
+) -> Result<()> {
+    for e in entries {
+        if cancelled() {
+            return Err(cancelled_err());
+        }
+        match e.entry_type {
+            EntryType::Directory => {
+                let sub = dest_dir.join(&e.name);
+                std::fs::create_dir_all(&sub)
+                    .with_context(|| format!("creating {}", sub.display()))?;
+                let children = fs
+                    .list_directory(e)
+                    .with_context(|| format!("listing '{}'", e.name))?;
+                folder_recurse(
+                    fs, &children, &sub, format, fork_mode, progress, cancelled, summary,
+                )?;
+            }
+            EntryType::File => {
+                match format {
+                    ExportFormat::LooseFiles => {
+                        export_file_with_fork(fs, e, dest_dir, &safe_name(e), fork_mode)
+                            .with_context(|| format!("exporting '{}'", e.name))?;
+                    }
+                    ExportFormat::GzipPerFile | ExportFormat::ZstdPerFile => {
+                        export_compressed_file(fs, e, dest_dir, format)
+                            .with_context(|| format!("compressing '{}'", e.name))?;
+                    }
+                    _ => anyhow::bail!("{:?} is not a folder-output format", format),
+                }
+                summary.files += 1;
+                summary.bytes = summary.bytes.saturating_add(e.size);
+                progress(&e.path, summary.files, summary.bytes);
+            }
+            EntryType::Symlink | EntryType::Special => {
+                // Not representable as a loose host file here; skip.
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Read a file's data fork fully into memory.
+fn read_data_fork(fs: &mut dyn Filesystem, e: &FileEntry) -> Result<Vec<u8>> {
+    let mut buf = Vec::with_capacity(e.size as usize);
+    fs.write_file_to(e, &mut buf)
+        .with_context(|| format!("reading '{}'", e.name))?;
+    Ok(buf)
+}
+
+/// Read a file's resource fork (empty when it has none).
+fn read_resource_fork(fs: &mut dyn Filesystem, e: &FileEntry) -> Vec<u8> {
+    let mut buf = Vec::new();
+    let _ = fs.write_resource_fork_to(e, &mut buf);
+    buf
+}
+
+/// Gzip/zstd one file's data fork to `<dest_dir>/<name>.<ext>`.
+fn export_compressed_file(
+    fs: &mut dyn Filesystem,
+    e: &FileEntry,
+    dest_dir: &Path,
+    format: ExportFormat,
+) -> Result<()> {
+    let data = read_data_fork(fs, e)?;
+    let ext = if format == ExportFormat::GzipPerFile {
+        "gz"
+    } else {
+        "zst"
+    };
+    let out_path = dest_dir.join(format!("{}.{ext}", safe_name(e)));
+    let out = std::fs::File::create(&out_path)
+        .with_context(|| format!("creating {}", out_path.display()))?;
+    match format {
+        ExportFormat::GzipPerFile => {
+            let mut enc = flate2::write::GzEncoder::new(out, flate2::Compression::default());
+            enc.write_all(&data)?;
+            enc.finish().context("finishing gzip stream")?;
+        }
+        ExportFormat::ZstdPerFile => {
+            let mut enc = crate::rbformats::zstd_compat::ZstdEncoder::new(out, 0)
+                .context("init zstd encoder")?;
+            enc.write_all(&data)?;
+            enc.finish().context("finishing zstd stream")?;
+        }
+        _ => unreachable!("caller guarantees a per-file format"),
+    }
+    Ok(())
+}
+
+/// Export `entries` from `fs` into the single archive file `out_path`. Only the
+/// [`ExportFormat::is_single_file`] formats are valid here.
+pub fn export_to_file(
+    fs: &mut dyn Filesystem,
+    entries: &[FileEntry],
+    out_path: &Path,
+    format: ExportFormat,
+    progress: &Progress,
+    cancelled: &Cancelled,
+) -> Result<ExportSummary> {
+    match format {
+        ExportFormat::Tar | ExportFormat::TarGz | ExportFormat::TarZstd => {
+            export_tar_file(fs, entries, out_path, format, progress)
+        }
+        ExportFormat::Zip => export_zip_file(fs, entries, out_path, progress, cancelled),
+        ExportFormat::StuffIt => export_sit_file(fs, entries, out_path, progress, cancelled),
+        _ => anyhow::bail!("{:?} is not a single-file format", format),
+    }
+}
+
+fn export_tar_file(
+    fs: &mut dyn Filesystem,
+    entries: &[FileEntry],
+    out_path: &Path,
+    format: ExportFormat,
+    progress: &Progress,
+) -> Result<ExportSummary> {
+    let compression = match format {
+        ExportFormat::Tar => TarCompression::None,
+        ExportFormat::TarGz => TarCompression::Gzip,
+        ExportFormat::TarZstd => TarCompression::Zstd,
+        _ => unreachable!(),
+    };
+    let out = std::fs::File::create(out_path)
+        .with_context(|| format!("creating {}", out_path.display()))?;
+    let opts = TarExportOptions::default();
+    let stats = export_tar_multi(fs, entries, out, compression, &opts, &|s| {
+        progress("", s.files as usize, s.total_bytes);
+    })?;
+    Ok(ExportSummary {
+        files: stats.files as usize,
+        bytes: stats.total_bytes,
+    })
+}
+
+fn export_zip_file(
+    fs: &mut dyn Filesystem,
+    entries: &[FileEntry],
+    out_path: &Path,
+    progress: &Progress,
+    cancelled: &Cancelled,
+) -> Result<ExportSummary> {
+    let out = std::fs::File::create(out_path)
+        .with_context(|| format!("creating {}", out_path.display()))?;
+    let mut zw = zip::ZipWriter::new(out);
+    let opts: zip::write::FileOptions<'_, ()> =
+        zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+    let mut summary = ExportSummary::default();
+    zip_recurse(
+        fs,
+        entries,
+        "",
+        &mut zw,
+        opts,
+        progress,
+        cancelled,
+        &mut summary,
+    )?;
+    zw.finish().context("finishing zip archive")?;
+    Ok(summary)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn zip_recurse<W: Write + std::io::Seek>(
+    fs: &mut dyn Filesystem,
+    entries: &[FileEntry],
+    prefix: &str,
+    zw: &mut zip::ZipWriter<W>,
+    opts: zip::write::FileOptions<'static, ()>,
+    progress: &Progress,
+    cancelled: &Cancelled,
+    summary: &mut ExportSummary,
+) -> Result<()> {
+    for e in entries {
+        if cancelled() {
+            return Err(cancelled_err());
+        }
+        let arch = if prefix.is_empty() {
+            e.name.clone()
+        } else {
+            format!("{prefix}/{}", e.name)
+        };
+        match e.entry_type {
+            EntryType::Directory => {
+                zw.add_directory(format!("{arch}/"), opts)
+                    .with_context(|| format!("zip dir '{arch}'"))?;
+                let children = fs
+                    .list_directory(e)
+                    .with_context(|| format!("listing '{}'", e.name))?;
+                zip_recurse(fs, &children, &arch, zw, opts, progress, cancelled, summary)?;
+            }
+            EntryType::File => {
+                let data = read_data_fork(fs, e)?;
+                zw.start_file(&arch, opts)
+                    .with_context(|| format!("zip file '{arch}'"))?;
+                zw.write_all(&data)?;
+                // Preserve a Mac resource fork / Finder info as the AppleDouble
+                // sidecar macOS' own Archive Utility writes into a zip.
+                let rsrc = read_resource_fork(fs, e);
+                if !rsrc.is_empty() || e.type_code.is_some() {
+                    let ad = build_appledouble(
+                        &e.type_code.unwrap_or([0; 4]),
+                        &e.creator_code.unwrap_or([0; 4]),
+                        mac_dates(e),
+                        &rsrc,
+                    );
+                    let sidecar = match arch.rsplit_once('/') {
+                        Some((dir, base)) => format!("__MACOSX/{dir}/._{base}"),
+                        None => format!("__MACOSX/._{arch}"),
+                    };
+                    zw.start_file(&sidecar, opts)
+                        .with_context(|| format!("zip sidecar '{sidecar}'"))?;
+                    zw.write_all(&ad)?;
+                }
+                summary.files += 1;
+                summary.bytes = summary.bytes.saturating_add(data.len() as u64);
+                progress(&e.path, summary.files, summary.bytes);
+            }
+            EntryType::Symlink | EntryType::Special => {}
+        }
+    }
+    Ok(())
+}
+
+fn export_sit_file(
+    fs: &mut dyn Filesystem,
+    entries: &[FileEntry],
+    out_path: &Path,
+    progress: &Progress,
+    cancelled: &Cancelled,
+) -> Result<ExportSummary> {
+    let mut summary = ExportSummary::default();
+    let nodes = sit_nodes(fs, entries, progress, cancelled, &mut summary)?;
+    let bytes = build_archive_tree(&nodes, WriteMethod::Rle).context("building StuffIt archive")?;
+    std::fs::write(out_path, &bytes).with_context(|| format!("writing {}", out_path.display()))?;
+    Ok(summary)
+}
+
+fn sit_nodes(
+    fs: &mut dyn Filesystem,
+    entries: &[FileEntry],
+    progress: &Progress,
+    cancelled: &Cancelled,
+    summary: &mut ExportSummary,
+) -> Result<Vec<StuffItInputNode>> {
+    let mut nodes = Vec::new();
+    for e in entries {
+        if cancelled() {
+            return Err(cancelled_err());
+        }
+        match e.entry_type {
+            EntryType::Directory => {
+                let children = fs
+                    .list_directory(e)
+                    .with_context(|| format!("listing '{}'", e.name))?;
+                let (create, modify) = sit_dates(e);
+                let inner = sit_nodes(fs, &children, progress, cancelled, summary)?;
+                nodes.push(StuffItInputNode::Folder {
+                    name: e.name.clone(),
+                    finder_flags: e.finder_flags.unwrap_or(0),
+                    create_date: create,
+                    mod_date: modify,
+                    children: inner,
+                });
+            }
+            EntryType::File => {
+                let data = read_data_fork(fs, e)?;
+                let rsrc = read_resource_fork(fs, e);
+                let (create, modify) = sit_dates(e);
+                summary.files += 1;
+                summary.bytes = summary.bytes.saturating_add(data.len() as u64);
+                progress(&e.path, summary.files, summary.bytes);
+                nodes.push(StuffItInputNode::File(StuffItInput {
+                    name: e.name.clone(),
+                    type_code: e.type_code.unwrap_or(*b"????"),
+                    creator_code: e.creator_code.unwrap_or(*b"????"),
+                    finder_flags: e.finder_flags.unwrap_or(0),
+                    create_date: create,
+                    mod_date: modify,
+                    data_fork: data,
+                    resource_fork: rsrc,
+                }));
+            }
+            EntryType::Symlink | EntryType::Special => {}
+        }
+    }
+    Ok(nodes)
+}
+
+/// Mac create/modify seconds (1904 epoch) from an entry's dates, 0 when unknown.
+fn sit_dates(e: &FileEntry) -> (u32, u32) {
+    match e.mac_dates {
+        Some((create, modify, _backup)) => (create, modify),
+        None => (0, 0),
+    }
+}
+
+fn mac_dates(e: &FileEntry) -> MacFileDates {
+    let (created, modified) = sit_dates(e);
+    MacFileDates { created, modified }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fs::filesystem::EditableFilesystem;
+    use std::io::Read;
+
+    fn put_file(efs: &mut dyn EditableFilesystem, parent: &FileEntry, name: &str, data: &[u8]) {
+        let mut r: &[u8] = data;
+        efs.create_file(parent, name, &mut r, data.len() as u64, &Default::default())
+            .unwrap();
+    }
+
+    /// A blank FAT volume holding `HELLO.TXT`, `DATA.BIN`, and `SUB/INNER.TXT`.
+    /// Returns the open (read-only) filesystem and its selected root entries.
+    fn fixture() -> (Box<dyn Filesystem>, Vec<FileEntry>, tempfile::TempDir) {
+        let flat = crate::fs::fat::create_blank_fat(2 * 1024 * 1024, Some("EXP")).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let img = dir.path().join("v.img");
+        std::fs::write(&img, &flat).unwrap();
+        {
+            let file = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&img)
+                .unwrap();
+            let mut efs = crate::fs::open_editable_filesystem(file, 0, 0, None).unwrap();
+            let root = efs.root().unwrap();
+            put_file(&mut *efs, &root, "HELLO.TXT", b"hello world");
+            let data: Vec<u8> = (0u8..250).collect();
+            put_file(&mut *efs, &root, "DATA.BIN", &data);
+            let sub = efs
+                .create_directory(&root, "SUB", &Default::default())
+                .unwrap();
+            put_file(&mut *efs, &sub, "INNER.TXT", b"nested file");
+            efs.sync_metadata().unwrap();
+        }
+        let file = std::fs::File::open(&img).unwrap();
+        let mut fs = crate::fs::open_filesystem(file, 0, 0, None).unwrap();
+        let root = fs.root().unwrap();
+        let entries = fs.list_directory(&root).unwrap();
+        (fs, entries, dir)
+    }
+
+    fn noprog(_: &str, _: usize, _: u64) {}
+    fn never() -> bool {
+        false
+    }
+
+    #[test]
+    fn loose_files_written_to_folder() {
+        let (mut fs, entries, _g) = fixture();
+        let out = tempfile::tempdir().unwrap();
+        let s = export_to_folder(
+            &mut *fs,
+            &entries,
+            out.path(),
+            ExportFormat::LooseFiles,
+            ResourceForkMode::Native,
+            &noprog,
+            &never,
+        )
+        .unwrap();
+        assert_eq!(s.files, 3);
+        assert_eq!(
+            std::fs::read(out.path().join("HELLO.TXT")).unwrap(),
+            b"hello world"
+        );
+        assert_eq!(
+            std::fs::read(out.path().join("SUB/INNER.TXT")).unwrap(),
+            b"nested file"
+        );
+    }
+
+    #[test]
+    fn gzip_per_file_round_trips() {
+        let (mut fs, entries, _g) = fixture();
+        let out = tempfile::tempdir().unwrap();
+        export_to_folder(
+            &mut *fs,
+            &entries,
+            out.path(),
+            ExportFormat::GzipPerFile,
+            ResourceForkMode::Native,
+            &noprog,
+            &never,
+        )
+        .unwrap();
+        let gz = std::fs::read(out.path().join("HELLO.TXT.gz")).unwrap();
+        let mut dec = flate2::read::GzDecoder::new(&gz[..]);
+        let mut got = Vec::new();
+        dec.read_to_end(&mut got).unwrap();
+        assert_eq!(got, b"hello world");
+    }
+
+    #[test]
+    fn tar_gz_contains_all_files() {
+        let (mut fs, entries, _g) = fixture();
+        let out = tempfile::tempdir().unwrap();
+        let path = out.path().join("out.tar.gz");
+        let s = export_to_file(
+            &mut *fs,
+            &entries,
+            &path,
+            ExportFormat::TarGz,
+            &noprog,
+            &never,
+        )
+        .unwrap();
+        assert_eq!(s.files, 3);
+        let f = std::fs::File::open(&path).unwrap();
+        let dec = flate2::read::GzDecoder::new(f);
+        let mut ar = tar::Archive::new(dec);
+        let names: Vec<String> = ar
+            .entries()
+            .unwrap()
+            .map(|e| e.unwrap().path().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert!(names.iter().any(|n| n == "HELLO.TXT"), "{names:?}");
+        assert!(names.iter().any(|n| n == "SUB/INNER.TXT"), "{names:?}");
+    }
+
+    #[test]
+    fn zip_contains_all_files() {
+        let (mut fs, entries, _g) = fixture();
+        let out = tempfile::tempdir().unwrap();
+        let path = out.path().join("out.zip");
+        export_to_file(
+            &mut *fs,
+            &entries,
+            &path,
+            ExportFormat::Zip,
+            &noprog,
+            &never,
+        )
+        .unwrap();
+        let f = std::fs::File::open(&path).unwrap();
+        let mut zip = zip::ZipArchive::new(f).unwrap();
+        let mut hello = zip.by_name("HELLO.TXT").unwrap();
+        let mut got = Vec::new();
+        hello.read_to_end(&mut got).unwrap();
+        assert_eq!(got, b"hello world");
+        drop(hello);
+        assert!(zip.by_name("SUB/INNER.TXT").is_ok());
+    }
+
+    #[test]
+    fn stuffit_round_trips_through_parser() {
+        let (mut fs, entries, _g) = fixture();
+        let out = tempfile::tempdir().unwrap();
+        let path = out.path().join("out.sit");
+        let s = export_to_file(
+            &mut *fs,
+            &entries,
+            &path,
+            ExportFormat::StuffIt,
+            &noprog,
+            &never,
+        )
+        .unwrap();
+        assert_eq!(s.files, 3);
+        let bytes = std::fs::read(&path).unwrap();
+        let archive = crate::macarchive::stuffit::parse(&bytes).unwrap();
+        let hello = archive
+            .entries
+            .iter()
+            .find(|e| e.name == "HELLO.TXT")
+            .expect("HELLO.TXT in sit");
+        let data =
+            crate::macarchive::stuffit::decompress_fork(&bytes, hello.data.as_ref().unwrap())
+                .unwrap();
+        assert_eq!(data, b"hello world");
+    }
+
+    #[test]
+    fn cancel_stops_export() {
+        let (mut fs, entries, _g) = fixture();
+        let out = tempfile::tempdir().unwrap();
+        let err = export_to_folder(
+            &mut *fs,
+            &entries,
+            out.path(),
+            ExportFormat::LooseFiles,
+            ResourceForkMode::Native,
+            &noprog,
+            &|| true,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("cancelled"), "{err}");
+    }
+}

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -23,6 +23,7 @@ pub mod entry;
 pub mod exfat;
 pub mod exfat_clone;
 pub mod exfat_fsck;
+pub mod export_selection;
 pub mod ext;
 pub mod ext_csum;
 pub mod ext_format;

--- a/src/fs/tar_export.rs
+++ b/src/fs/tar_export.rs
@@ -164,6 +164,59 @@ pub fn export_tar<W: Write>(
     Ok(stats)
 }
 
+/// Archive several `roots` (a Commander selection of files/folders) into `out`
+/// as one tar stream, each placed at the archive root under its own name (a file
+/// `foo` becomes `foo`, a directory `bar` becomes `bar/…`). Same engine as
+/// [`export_tar`]; use this when the selection is more than a single subtree.
+pub fn export_tar_multi<W: Write>(
+    fs: &mut dyn Filesystem,
+    roots: &[FileEntry],
+    out: W,
+    compression: TarCompression,
+    opts: &TarExportOptions,
+    progress: &dyn Fn(&TarExportStats),
+) -> Result<TarExportStats> {
+    let mut stats = TarExportStats::default();
+    match compression {
+        TarCompression::Gzip => {
+            let enc = flate2::write::GzEncoder::new(out, flate2::Compression::default());
+            let mut builder = tar::Builder::new(enc);
+            write_roots(fs, roots, &mut builder, opts, &mut stats, progress)?;
+            let enc = builder.into_inner().context("finishing tar stream")?;
+            enc.finish().context("finishing gzip stream")?;
+        }
+        TarCompression::Zstd => {
+            let enc = crate::rbformats::zstd_compat::ZstdEncoder::new(out, 0)
+                .context("init zstd encoder")?;
+            let mut builder = tar::Builder::new(enc);
+            write_roots(fs, roots, &mut builder, opts, &mut stats, progress)?;
+            let enc = builder.into_inner().context("finishing tar stream")?;
+            enc.finish().context("finishing zstd stream")?;
+        }
+        TarCompression::None => {
+            let mut builder = tar::Builder::new(out);
+            write_roots(fs, roots, &mut builder, opts, &mut stats, progress)?;
+            builder.into_inner().context("finishing tar stream")?;
+        }
+    }
+    Ok(stats)
+}
+
+/// Append each selected root to `builder` under its own name.
+fn write_roots<W: Write>(
+    fs: &mut dyn Filesystem,
+    roots: &[FileEntry],
+    builder: &mut tar::Builder<W>,
+    opts: &TarExportOptions,
+    stats: &mut TarExportStats,
+    progress: &dyn Fn(&TarExportStats),
+) -> Result<()> {
+    for root in roots {
+        export_into(fs, root, &root.name, builder, opts, stats, progress)?;
+    }
+    Ok(())
+}
+
 fn export_into<W: Write>(
     fs: &mut dyn Filesystem,
     root: &FileEntry,

--- a/src/gui/commander/mod.rs
+++ b/src/gui/commander/mod.rs
@@ -989,10 +989,14 @@ impl CommanderMode {
             Side::Left => &mut self.left,
             Side::Right => &mut self.right,
         };
-        // A writable image volume gets the metadata editors; host folders and
-        // read-only backups / archives show the metadata without them.
-        let editable = !pane.is_host_pane() && !pane.is_backup_pane() && !pane.is_archive_pane();
-        let fs_type = pane.fs_type().to_string();
+        // A writable image volume gets the metadata editors; host folders,
+        // read-only backups / archives, and wrapper contents (copy out, don't
+        // edit) show the metadata without them.
+        let editable = !pane.is_host_pane()
+            && !pane.is_backup_pane()
+            && !pane.is_archive_pane()
+            && !pane.wrapper_selection_active();
+        let fs_type = pane.detail_fs_type();
         let Some((entry, bytes)) = pane.detail_payload(&name, MAX_PREVIEW_SIZE) else {
             return format!("[{}] could not open File Info for '{name}'.", from.label());
         };

--- a/src/gui/commander/mod.rs
+++ b/src/gui/commander/mod.rs
@@ -22,10 +22,13 @@ use std::sync::{Arc, Mutex};
 use eframe::egui;
 
 use rusty_backup::fs::entry::FileEntry;
+use rusty_backup::fs::export_selection::ExportFormat;
 use rusty_backup::fs::fork_export::{export_file_with_fork, safe_name};
 use rusty_backup::fs::resource_fork::ResourceForkMode;
 use rusty_backup::model::checksum::{self, ChecksumJob, ChecksumStatus};
-use rusty_backup::model::commander_ops::{self, HostCopyJob, HostCopyStatus, StageCopyStatus};
+use rusty_backup::model::commander_ops::{
+    self, ExportJob, HostCopyJob, HostCopyStatus, StageCopyStatus,
+};
 use rusty_backup::partition::format_size;
 
 use super::file_detail::{self, FileContent};
@@ -147,6 +150,10 @@ pub struct CommanderMode {
     /// a host folder (MacBinary / BinHex / AppleDouble / … via
     /// [`export_file_with_fork`]). Ignored for host->host copies.
     export_fork_mode: ResourceForkMode,
+    /// The default output shape for "Export to hard drive..." — loose files, a
+    /// per-file-compressed tree, or a single tar/zip/sit archive. The row menu's
+    /// "Export as" submenu can override it per action.
+    export_format: ExportFormat,
     /// The pane the user last interacted with — the middle-column Delete acts
     /// on it. Updated from each pane's `focused` response.
     active: Side,
@@ -182,6 +189,7 @@ impl CommanderMode {
             detail: None,
             keep_dates: true,
             export_fork_mode: ResourceForkMode::MacBinary,
+            export_format: ExportFormat::LooseFiles,
             active: Side::Left,
             session_log: Vec::new(),
             show_log: false,
@@ -290,7 +298,10 @@ impl CommanderMode {
                             self.status = self.copy(Side::Left);
                         }
                         if resp.export_to_host {
-                            self.status = self.export(Side::Left);
+                            self.status = self.export(Side::Left, None);
+                        }
+                        if let Some(fmt) = resp.export_as {
+                            self.status = self.export(Side::Left, Some(fmt));
                         }
                         if resp.checksums {
                             self.status = self.start_checksums(Side::Left);
@@ -329,7 +340,10 @@ impl CommanderMode {
                             self.status = self.copy(Side::Right);
                         }
                         if resp.export_to_host {
-                            self.status = self.export(Side::Right);
+                            self.status = self.export(Side::Right, None);
+                        }
+                        if let Some(fmt) = resp.export_as {
+                            self.status = self.export(Side::Right, Some(fmt));
                         }
                         if resp.checksums {
                             self.status = self.start_checksums(Side::Right);
@@ -463,24 +477,43 @@ impl CommanderMode {
                  stamping the current time. Image-to-image copies only.",
             );
         ui.add_space(8.0);
-        // Resource-fork format for image->host copies / exports. When copying a
-        // Mac file out to a host folder, its resource fork is preserved in the
-        // chosen container (MacBinary / BinHex / AppleDouble / …).
-        ui.label("Export forks as:");
-        egui::ComboBox::from_id_salt("commander_fork_mode")
-            .selected_text(self.export_fork_mode.label())
+        // Output shape for "Export to hard drive..." — loose files, a per-file
+        // compressed tree, or a single tar/zip/sit archive.
+        ui.label("Export as:");
+        egui::ComboBox::from_id_salt("commander_export_format")
+            .selected_text(self.export_format.label())
             .width(150.0)
             .show_ui(ui, |ui| {
-                for mode in ResourceForkMode::ALL {
-                    ui.selectable_value(&mut self.export_fork_mode, mode, mode.label());
+                for fmt in ExportFormat::ALL {
+                    ui.selectable_value(&mut self.export_format, fmt, fmt.label());
                 }
             })
             .response
             .on_hover_text(
-                "How to preserve a Mac file's resource fork when copying it out to \
-                 a host folder (image->host copies and Export). Host->host copies \
-                 keep bytes as-is.",
+                "How the row menu's \"Export to hard drive...\" writes the selection \
+                 out. The row menu's \"Export as\" submenu can pick a format inline.",
             );
+        ui.add_space(4.0);
+        // Resource-fork container, used only by the "Loose files" format. When
+        // exporting a Mac file out, its resource fork is preserved in the chosen
+        // container (MacBinary / BinHex / AppleDouble / …).
+        ui.add_enabled_ui(self.export_format == ExportFormat::LooseFiles, |ui| {
+            ui.label("Forks as:");
+            egui::ComboBox::from_id_salt("commander_fork_mode")
+                .selected_text(self.export_fork_mode.label())
+                .width(150.0)
+                .show_ui(ui, |ui| {
+                    for mode in ResourceForkMode::ALL {
+                        ui.selectable_value(&mut self.export_fork_mode, mode, mode.label());
+                    }
+                })
+                .response
+                .on_hover_text(
+                    "How to preserve a Mac file's resource fork when exporting loose \
+                     files. Tar keeps data forks only; Zip and StuffIt carry forks \
+                     natively.",
+                );
+        });
         status
     }
 
@@ -616,11 +649,12 @@ impl CommanderMode {
     /// independent of what the other pane shows; this is the immediate host
     /// write engine ([`commander_ops::spawn_host_copy`]) with no re-list on
     /// completion (the picked folder isn't a pane).
-    fn export(&mut self, from: Side) -> String {
+    fn export(&mut self, from: Side, format_override: Option<ExportFormat>) -> String {
         if self.pending_host_copy.is_some() {
             return "A copy is already in progress; wait for it to finish.".to_string();
         }
         let fork_mode = self.export_fork_mode;
+        let format = format_override.unwrap_or(self.export_format);
         let src = match from {
             Side::Left => &mut self.left,
             Side::Right => &mut self.right,
@@ -629,40 +663,69 @@ impl CommanderMode {
         if entries.is_empty() {
             return format!("Nothing selected in the {} pane to export.", from.label());
         }
-        let Some(dest_dir) = super::file_dialog().pick_folder() else {
-            return "Export cancelled.".to_string();
+        // A host source has no `Filesystem` to read archive members from, so only
+        // loose files are supported there — reject before prompting for a dest.
+        if src.is_host_pane() && format != ExportFormat::LooseFiles {
+            return format!(
+                "'{}' export runs from an image/volume source; a host folder can only \
+                 export as loose files.",
+                format.label()
+            );
+        }
+
+        // Single-file formats prompt for an archive filename; folder formats
+        // (loose / per-file) prompt for a destination directory.
+        let dest = if format.is_single_file() {
+            let ext = format.file_extension().unwrap_or("out");
+            let name = export_archive_name(&entries, ext);
+            let Some(p) = super::file_dialog()
+                .set_file_name(&name)
+                .add_filter(format.label(), &[ext])
+                .save_file()
+            else {
+                return "Export cancelled.".to_string();
+            };
+            p
+        } else {
+            let Some(d) = super::file_dialog().pick_folder() else {
+                return "Export cancelled.".to_string();
+            };
+            d
         };
 
+        // Host source + loose files: an immediate host-to-host copy.
         if src.is_host_pane() {
-            let job = HostCopyJob::HostToHost { entries, dest_dir };
-            self.pending_host_copy = Some((None, commander_ops::spawn_host_copy(job)));
-            return format!(
-                "Exporting the {} pane selection to the host folder...",
-                from.label()
-            );
-        }
-        // A reopenable source (local session or remote image) extracts on a
-        // worker with progress; a wrapper-tree mount (small, local) has no
-        // reopenable handle, so extract synchronously over its live fs.
-        if let Some(source) = src.copy_stage_source() {
-            let job = HostCopyJob::ImageToHost {
-                source,
+            let job = HostCopyJob::HostToHost {
                 entries,
-                dest_dir,
-                fork_mode,
+                dest_dir: dest,
             };
             self.pending_host_copy = Some((None, commander_ops::spawn_host_copy(job)));
+            return format!("Exporting the {} pane selection...", from.label());
+        }
+        // A reopenable image source (local session, remote image, archive, or an
+        // inline disk-image/optical wrapper) exports on a worker with progress.
+        if let Some(source) = src.copy_stage_source() {
+            let job = HostCopyJob::ExportSelection(Box::new(ExportJob {
+                source,
+                entries,
+                dest,
+                format,
+                fork_mode,
+            }));
+            self.pending_host_copy = Some((None, commander_ops::spawn_host_copy(job)));
             return format!(
-                "Exporting the {} pane selection to the host folder...",
-                from.label()
+                "Exporting the {} pane selection as {}...",
+                from.label(),
+                format.label()
             );
         }
+        // A non-reopenable wrapper mount (small, local): export synchronously.
         let Some(src_fs) = src.fs_mut() else {
             return "Source volume is not open.".to_string();
         };
-        match extract_entries_to_host(src_fs, &entries, &dest_dir, fork_mode) {
-            Ok(n) => format!("Exported {n} item(s) to {}.", dest_dir.display()),
-            Err(e) => format!("Export failed: {e}"),
+        match commander_ops::export_now(src_fs, &entries, &dest, format, fork_mode) {
+            Ok(s) => format!("Exported {} file(s) to {}.", s.files, dest.display()),
+            Err(e) => format!("Export failed: {e:#}"),
         }
     }
 
@@ -1224,6 +1287,21 @@ fn extract_entries_to_host(
 
 fn log_timestamp() -> String {
     chrono::Local::now().format("%H:%M:%S").to_string()
+}
+
+/// Default filename for a single-file export: `<stem>.<ext>` when exactly one
+/// entry is selected (its own name, minus any extension), else `export.<ext>`.
+fn export_archive_name(entries: &[FileEntry], ext: &str) -> String {
+    let stem = match entries {
+        [only] => only
+            .name
+            .rsplit_once('.')
+            .map(|(s, _)| s)
+            .filter(|s| !s.is_empty())
+            .unwrap_or(&only.name),
+        _ => "export",
+    };
+    format!("{stem}.{ext}")
 }
 
 // --- procedural button icons -----------------------------------------------

--- a/src/gui/commander/mod.rs
+++ b/src/gui/commander/mod.rs
@@ -392,26 +392,22 @@ impl CommanderMode {
         let l_can = idle && self.left.has_selection() && self.right.can_receive();
         let r_can = idle && self.right.has_selection() && self.left.can_receive();
 
-        // Copy into a remote *host* folder isn't supported yet (only remote disk
-        // images) — surface that in the hover so the greyed button reads as
-        // "not yet" rather than "broken".
-        const REMOTE_HOST_HINT: &str =
-            "Copying into a remote host folder isn't supported yet — only remote disk images";
-        let l_copy_hover = if self.right.is_remote_host_dest() {
-            REMOTE_HOST_HINT
-        } else {
-            "Copy the left pane's selection into the right pane"
+        // When a destination can't receive a copy, say why in the hover so the
+        // greyed button reads as "by design" rather than "broken": read-only
+        // media (archive / backup / remote host folder) each give a reason.
+        let l_copy_hover = match self.right.readonly_reason() {
+            Some(reason) => format!("Can't copy into the right pane — {reason}"),
+            None => "Copy the left pane's selection into the right pane".to_string(),
         };
-        let r_copy_hover = if self.left.is_remote_host_dest() {
-            REMOTE_HOST_HINT
-        } else {
-            "Copy the right pane's selection into the left pane"
+        let r_copy_hover = match self.left.readonly_reason() {
+            Some(reason) => format!("Can't copy into the left pane — {reason}"),
+            None => "Copy the right pane's selection into the left pane".to_string(),
         };
 
         // Pictured buttons (procedurally painted — no font glyphs, no assets):
         // stacked floppies + arrow for copy, a floppy with a red X for delete,
         // and "101=011?" for the (disabled) compare.
-        if icon_button(ui, sz, l_can, l_copy_hover, |p, r, c| {
+        if icon_button(ui, sz, l_can, &l_copy_hover, |p, r, c| {
             draw_copy_icon(p, r, c, true)
         })
         .clicked()
@@ -419,7 +415,7 @@ impl CommanderMode {
             status = Some(self.copy(Side::Left));
         }
         ui.add_space(6.0);
-        if icon_button(ui, sz, r_can, r_copy_hover, |p, r, c| {
+        if icon_button(ui, sz, r_can, &r_copy_hover, |p, r, c| {
             draw_copy_icon(p, r, c, false)
         })
         .clicked()

--- a/src/gui/commander/pane.rs
+++ b/src/gui/commander/pane.rs
@@ -27,6 +27,7 @@ use std::sync::{Arc, Mutex};
 use eframe::egui;
 
 use rusty_backup::fs::entry::FileEntry;
+use rusty_backup::fs::export_selection::ExportFormat;
 use rusty_backup::fs::filesystem::Filesystem;
 use rusty_backup::fs::partition_is_browsable;
 use rusty_backup::model::browse_session::{BrowseOpenStatus, BrowseSession};
@@ -74,9 +75,13 @@ pub(crate) struct PaneResponse {
     /// The user asked (via the row menu) to copy this pane's selection to the
     /// other pane; `CommanderMode` performs the cross-pane copy.
     pub copy_to_other: bool,
-    /// The user asked (via the row menu) to export this pane's selection to a
-    /// host folder they pick; `CommanderMode` runs the threaded host write.
+    /// The user asked (via the row menu) to export this pane's selection to the
+    /// host using the middle-column "Export as" format; `CommanderMode` runs the
+    /// threaded write.
     pub export_to_host: bool,
+    /// The user picked a specific format from the row menu's "Export" submenu,
+    /// overriding the dropdown for this one export.
+    pub export_as: Option<ExportFormat>,
     /// The user asked (via the row menu) to calculate checksums for this pane's
     /// selection; `CommanderMode` opens the threaded checksum window.
     pub checksums: bool,
@@ -99,8 +104,10 @@ struct RowActions {
     status: Option<String>,
     /// Copy the selection to the other pane.
     copy: bool,
-    /// Export the selection to a picked host folder.
+    /// Export the selection to the host using the dropdown's "Export as" format.
     export: bool,
+    /// Export the selection in a format picked from the "Export" submenu.
+    export_as: Option<ExportFormat>,
     /// Calculate checksums for the selection.
     checksums: bool,
     /// Open the File Info window for this entry (by name).
@@ -534,6 +541,7 @@ impl CommanderPane {
         }
         let mut copy_to_other = false;
         let mut export_to_host = false;
+        let mut export_as: Option<ExportFormat> = None;
         let mut checksums = false;
         let mut detail = None;
         let mut focused = false;
@@ -651,6 +659,7 @@ impl CommanderPane {
             }
             copy_to_other = actions.copy;
             export_to_host = actions.export;
+            export_as = actions.export_as;
             checksums = actions.checksums;
             detail = actions.detail;
             focused = actions.focused;
@@ -696,6 +705,7 @@ impl CommanderPane {
             status,
             copy_to_other,
             export_to_host,
+            export_as,
             checksums,
             detail,
             focused,
@@ -2625,6 +2635,7 @@ impl CommanderPane {
         let mut m_host_delete = false;
         let mut m_copy = false;
         let mut m_export = false;
+        let mut m_export_as: Option<ExportFormat> = None;
         let mut m_checksums = false;
         let mut m_rename: Option<String> = None;
         let mut m_cancel_rename: Option<String> = None;
@@ -2743,15 +2754,23 @@ impl CommanderPane {
                                 m_copy = true;
                                 ui.close();
                             }
-                            // Export the selection to a host folder the user
-                            // picks (loose files, not an archive). Like Copy,
-                            // it needs real data, so a not-yet-applied staged
-                            // add is excluded.
-                            if !matches!(row.kind, RowKind::PendingAdd)
-                                && ui.button("Export to hard drive...").clicked()
-                            {
-                                m_export = true;
-                                ui.close();
+                            // Export the selection to the host. "Export to hard
+                            // drive..." uses the middle-column "Export as" format;
+                            // the "Export" submenu picks a format inline. Needs
+                            // real data, so a not-yet-applied staged add is out.
+                            if !matches!(row.kind, RowKind::PendingAdd) {
+                                if ui.button("Export to hard drive...").clicked() {
+                                    m_export = true;
+                                    ui.close();
+                                }
+                                ui.menu_button("Export as", |ui| {
+                                    for fmt in ExportFormat::ALL {
+                                        if ui.button(fmt.label()).clicked() {
+                                            m_export_as = Some(fmt);
+                                            ui.close();
+                                        }
+                                    }
+                                });
                             }
                             // Checksums need real data, so a not-yet-applied
                             // staged add is excluded (same as Copy / Export).
@@ -2947,6 +2966,7 @@ impl CommanderPane {
             status,
             copy: m_copy,
             export: m_export,
+            export_as: m_export_as,
             checksums: m_checksums,
             detail: m_info,
             open_image: m_open_image,

--- a/src/gui/commander/pane.rs
+++ b/src/gui/commander/pane.rs
@@ -34,7 +34,9 @@ use rusty_backup::model::cache_runner;
 use rusty_backup::model::commander_descend::{
     classify_entry, open_archive, DescendKind, ReopenRecipe,
 };
-use rusty_backup::model::commander_ops::{self, ApplyStatus};
+use rusty_backup::model::commander_ops::{
+    self, ApplyStatus, WrapperExtract, WrapperOpenPlan, WrapperOpenStatus,
+};
 use rusty_backup::model::commander_source;
 use rusty_backup::model::dir_listing::{type_tag, DirListing, Row, SortColumn};
 use rusty_backup::model::edit_queue::{EditQueue, StagedEdit};
@@ -137,6 +139,10 @@ pub(crate) struct CommanderPane {
     /// `cache_runner::spawn_partclone_scan`. On completion `poll_scan` builds a
     /// partclone-cache session and hands off to `pending_open`.
     pending_scan: Option<Arc<Mutex<BlockCacheScan>>>,
+    /// In-flight async wrapper expansion (a large `.toast`/`.chd`/`.iso` being
+    /// materialized + probed off the UI thread). `poll_wrapper` installs the
+    /// mount when it finishes; a spinner shows meanwhile.
+    pending_wrapper: Option<PendingWrapper>,
     /// Scanned Clonezilla block caches reused across opens this session. The
     /// shared store also holds the in-memory/on-disk/scan decision tree so this
     /// pane and the Inspect tab agree (see `commander_source::PartcloneCacheStore`).
@@ -271,6 +277,14 @@ enum PendingSwitch {
     Close,
 }
 
+/// An in-flight async wrapper expansion: the node being opened, its display
+/// name (for the spinner + status), and the worker's shared status handle.
+struct PendingWrapper {
+    node_id: String,
+    name: String,
+    status: Arc<Mutex<WrapperOpenStatus>>,
+}
+
 impl CommanderPane {
     pub(crate) fn new(side: Side) -> Self {
         Self {
@@ -285,6 +299,7 @@ impl CommanderPane {
             pending_open: None,
             pending_apply: None,
             pending_scan: None,
+            pending_wrapper: None,
             cache_store: commander_source::PartcloneCacheStore::new(),
             open_phase: String::new(),
             open_rate: super::super::progress::RateTracker::default(),
@@ -386,7 +401,15 @@ impl CommanderPane {
                 self.wrapper_tree.expand_folder(node_id);
             }
         } else {
-            // Base wrapper: its bytes come from the host file or the base fs.
+            // Base wrapper: open it off the UI thread with a spinner —
+            // materializing a large `.toast`/`.chd`/`.iso` to a temp file and
+            // probing it can take seconds. Only one wrapper opens at a time.
+            if self.pending_wrapper.is_some() {
+                let side = self.side.label();
+                return Some(format!(
+                    "[{side}] a wrapper is already opening; wait for it."
+                ));
+            }
             let entry = self
                 .listing
                 .entries()
@@ -397,9 +420,15 @@ impl CommanderPane {
             // A host file opens by its real path — cheaper than reading it all,
             // and required for multi-file optical formats (bin/cue, mdf/mds)
             // whose sibling data file sits next to it. A wrapper inside an image
-            // pane must be read out of that filesystem first.
-            let source = if self.listing.is_host() {
-                WrapperSource::Path(PathBuf::from(&entry.path))
+            // pane is extracted on the worker from a fresh reopen of the base
+            // source; a non-reopenable base (rare) extracts synchronously here.
+            let plan = if self.listing.is_host() {
+                WrapperOpenPlan::HostPath(PathBuf::from(&entry.path))
+            } else if let Some(base) = self.base_stage_source() {
+                WrapperOpenPlan::Extract(Box::new(WrapperExtract {
+                    base,
+                    entry: entry.clone(),
+                }))
             } else {
                 let Some(fs) = self.listing.fs_mut() else {
                     return self.wrapper_open_failed(name, "source is not open".into());
@@ -408,19 +437,52 @@ impl CommanderPane {
                 if let Err(e) = fs.write_file_to(&entry, &mut buf) {
                     return self.wrapper_open_failed(name, e.to_string());
                 }
-                WrapperSource::Bytes(buf)
+                WrapperOpenPlan::Bytes(buf)
             };
-            if let Err(e) = self
-                .wrapper_tree
-                .expand_wrapper(node_id, name, kind, source)
-            {
-                return self.wrapper_open_failed(name, format!("{e:#}"));
-            }
+            self.pending_wrapper = Some(PendingWrapper {
+                node_id: node_id.to_string(),
+                name: name.to_string(),
+                status: commander_ops::spawn_wrapper_open(plan, kind, name.to_string()),
+            });
+            return Some(format!("[{}] opening {name}...", self.side.label()));
         }
         let side = self.side.label();
         self.wrapper_tree
             .note(node_id)
             .map(|n| format!("[{side}] {name}: {n}"))
+    }
+
+    /// The reopen handle for this pane's *base* source (ignoring any active
+    /// wrapper-tree selection) — a local image session, a remote image, or a Mac
+    /// archive by path. Used to extract a base wrapper's bytes on a worker so a
+    /// large expand doesn't freeze the UI. `None` for a host base (opened by
+    /// path instead) or a source with no reopenable handle.
+    fn base_stage_source(&self) -> Option<commander_ops::StageSource> {
+        if let Some(session) = self.session.clone() {
+            return Some(commander_ops::StageSource::Session(session));
+        }
+        #[cfg(feature = "remote")]
+        if let Some(RemoteConn {
+            addr,
+            mode: BrowseMode::Image { path, partition },
+        }) = &self.remote
+        {
+            return Some(commander_ops::StageSource::Remote {
+                addr: addr.clone(),
+                path: path.clone(),
+                partition: *partition,
+            });
+        }
+        if self.archive_source {
+            if let Some(path) = &self.source {
+                let label = path.file_name().map(|n| n.to_string_lossy().into_owned());
+                return Some(commander_ops::StageSource::Reopen(ReopenRecipe::Archive {
+                    path: path.clone(),
+                    label,
+                }));
+            }
+        }
+        None
     }
 
     /// Record a failed wrapper expansion in the session log (where the full
@@ -454,12 +516,17 @@ impl CommanderPane {
             self.last_cwd = cwd_now;
             self.wrapper_tree.clear();
             self.tree_selected.clear();
+            // Abandon any wrapper open still in flight — its target row is gone.
+            self.pending_wrapper = None;
         }
         let mut status = self.poll_open(ui.ctx());
         if let Some(s) = self.poll_apply(ui.ctx()) {
             status = Some(s);
         }
         if let Some(s) = self.poll_scan(ui.ctx()) {
+            status = Some(s);
+        }
+        if let Some(s) = self.poll_wrapper(ui.ctx()) {
             status = Some(s);
         }
         if let Some(s) = self.poll_remote(ui.ctx()) {
@@ -476,6 +543,27 @@ impl CommanderPane {
         }
         self.path_line(ui);
         ui.separator();
+
+        // A wrapper being opened off-thread: show a spinner + phase above the
+        // still-visible listing (the expand is inline, so the base rows stay).
+        if let Some(pw) = &self.pending_wrapper {
+            let phase = pw
+                .status
+                .lock()
+                .ok()
+                .map(|g| g.phase.clone())
+                .unwrap_or_default();
+            ui.horizontal(|ui| {
+                ui.add_space(8.0);
+                ui.spinner();
+                ui.label(if phase.is_empty() {
+                    format!("Opening {}...", pw.name)
+                } else {
+                    format!("{}: {}", pw.name, phase)
+                });
+            });
+            ui.ctx().request_repaint();
+        }
 
         if self.pending_apply.is_some() {
             ui.add_space(20.0);
@@ -1835,6 +1923,7 @@ impl CommanderPane {
         self.pending_open = None;
         self.pending_apply = None;
         self.pending_scan = None;
+        self.pending_wrapper = None;
         self.open_phase.clear();
         self.volume_label.clear();
         self.fs_type.clear();
@@ -2206,6 +2295,33 @@ impl CommanderPane {
             "[{}] metadata ready; opening...",
             self.side.label()
         ))
+    }
+
+    /// Poll an in-flight async wrapper expansion; on completion, install the
+    /// prepared mount (or record the failure) and drop the spinner.
+    fn poll_wrapper(&mut self, ctx: &egui::Context) -> Option<String> {
+        let finished = {
+            let pw = self.pending_wrapper.as_ref()?;
+            ctx.request_repaint();
+            pw.status.lock().ok().map(|g| g.finished).unwrap_or(false)
+        };
+        if !finished {
+            return None;
+        }
+        let pw = self.pending_wrapper.take()?;
+        let result = pw.status.lock().ok().and_then(|mut g| g.result.take());
+        match result {
+            Some(Ok(prepared)) => {
+                let note = self.wrapper_tree.install_prepared(&pw.node_id, prepared);
+                let side = self.side.label();
+                Some(match note {
+                    Some(n) => format!("[{side}] {}: {n}", pw.name),
+                    None => format!("[{side}] opened {}.", pw.name),
+                })
+            }
+            Some(Err(e)) => self.wrapper_open_failed(&pw.name, e),
+            None => None,
+        }
     }
 
     /// Poll an in-flight open; on completion, hand the filesystem + root listing

--- a/src/gui/commander/pane.rs
+++ b/src/gui/commander/pane.rs
@@ -60,6 +60,9 @@ const META_COLOR: egui::Color32 = egui::Color32::from_rgb(150, 190, 255);
 const IMAGE_COLOR: egui::Color32 = egui::Color32::from_rgb(110, 210, 190);
 /// The "Close Image" affordance — amber, to read as "step back out".
 const CLOSE_IMAGE_COLOR: egui::Color32 = egui::Color32::from_rgb(230, 170, 90);
+/// The "Read-only" media badge in the volume readout — amber, "look but touch
+/// carefully".
+const READ_ONLY_BADGE_COLOR: egui::Color32 = egui::Color32::from_rgb(230, 170, 90);
 
 /// What a pane reports back to [`super::CommanderMode`] after a frame.
 #[derive(Default)]
@@ -1218,6 +1221,34 @@ impl CommanderPane {
             && (self.remote.is_none() || self.is_remote_image())
     }
 
+    /// True when this pane's source is read-only media that can never receive a
+    /// copy — a Mac archive, a backup folder, or a remote host folder (no
+    /// host-write verb yet). Distinct from `can_receive`, which is also false
+    /// for transient states (mid-open/apply); this reflects the *medium*, so the
+    /// pane header can show a "Read-only" badge. Host folders and writable image
+    /// volumes are not read-only.
+    pub(crate) fn is_read_only(&self) -> bool {
+        self.listing.is_loaded()
+            && !self.listing.is_host()
+            && (self.archive_source
+                || self.resolved_backup.is_some()
+                || (self.remote.is_some() && !self.is_remote_image()))
+    }
+
+    /// A short reason a copy into this pane is refused, for the copy button's
+    /// disabled hover. `None` when the pane can receive.
+    pub(crate) fn readonly_reason(&self) -> Option<&'static str> {
+        if self.archive_source {
+            Some("the archive is read-only")
+        } else if self.resolved_backup.is_some() {
+            Some("the backup is read-only")
+        } else if self.remote.is_some() && !self.is_remote_image() {
+            Some("a remote host folder can't receive copies yet")
+        } else {
+            None
+        }
+    }
+
     /// True when this pane lists a host-OS folder rather than a disk image.
     /// When a wrapper selection is active the effective source is the mounted
     /// wrapper filesystem (not the host), so report `false`.
@@ -1469,13 +1500,6 @@ impl CommanderPane {
     /// write path doesn't carry yet (delete / rename over the wire).
     pub(crate) fn is_remote(&self) -> bool {
         self.remote.is_some()
-    }
-
-    /// True when this pane is a remote *host* folder — a copy destination the
-    /// write path can't reach yet (the daemon has no host-write verb; only
-    /// remote disk images can be written). Drives the Copy button's hint.
-    pub(crate) fn is_remote_host_dest(&self) -> bool {
-        self.remote.is_some() && !self.is_remote_image()
     }
 
     /// Open a drag-and-dropped path as this pane's source (drag-and-drop router).
@@ -1779,6 +1803,17 @@ impl CommanderPane {
                     ui.separator();
                     let free = self.total_size.saturating_sub(self.used_size);
                     ui.label(format!("free: {}", format_size(free)));
+                    // Read-only media (archive / backup / remote host): flag it so
+                    // the greyed copy-into button reads as "by design", and edits
+                    // aren't attempted.
+                    if self.is_read_only() {
+                        ui.separator();
+                        ui.colored_label(READ_ONLY_BADGE_COLOR, "Read-only")
+                            .on_hover_text(
+                                "This source can be browsed and copied out of, but not \
+                                 written to — copies into this pane are disabled.",
+                            );
+                    }
                 }
             });
         }

--- a/src/gui/commander/pane.rs
+++ b/src/gui/commander/pane.rs
@@ -1415,6 +1415,18 @@ impl CommanderPane {
         name: &str,
         max: usize,
     ) -> Option<(FileEntry, Option<Vec<u8>>)> {
+        // A wrapper-tree row (a file inside an expanded .sit / .toast / disk-image
+        // wrapper): resolve against the active tree selection — a right-click
+        // selects the row first — and read through the mounted wrapper fs.
+        if self.tree_active() {
+            let (_, entries) = self.tree_selection()?;
+            let entry = entries.into_iter().find(|e| e.name == name)?;
+            if !entry.is_file() {
+                return Some((entry, None));
+            }
+            let data = self.fs_mut().and_then(|fs| fs.read_file(&entry, max).ok());
+            return Some((entry, data));
+        }
         let entry = self
             .listing
             .entries()
@@ -1432,6 +1444,24 @@ impl CommanderPane {
                 .and_then(|fs| fs.read_file(&entry, max).ok())
         };
         Some((entry, data))
+    }
+
+    /// True when an expanded-wrapper row is the active selection. Its contents
+    /// are read-only (copy out, don't edit), so File Info shows no editors.
+    pub(crate) fn wrapper_selection_active(&self) -> bool {
+        self.tree_active()
+    }
+
+    /// The filesystem type to show in File Info: the mounted wrapper's type
+    /// when a tree selection is active (e.g. "HFS" for a file inside a `.toast`
+    /// opened through a `.sit`), else the base pane's type.
+    pub(crate) fn detail_fs_type(&mut self) -> String {
+        if let Some((mount, _)) = self.tree_selection() {
+            if let Some(fs) = self.wrapper_tree.mount_fs(&mount) {
+                return fs.fs_type().to_string();
+            }
+        }
+        self.fs_type().to_string()
     }
 
     /// True when this pane is browsing a remote daemon (host FS or an image on
@@ -2580,11 +2610,12 @@ impl CommanderPane {
                                 m_checksums = true;
                                 ui.close();
                             }
-                            // File Info / Details: metadata + preview, with the
-                            // editable-metadata subset on image panes. Needs
-                            // real data, so a not-yet-applied add is excluded.
-                            if !row.is_tree
-                                && !matches!(row.kind, RowKind::PendingAdd)
+                            // File Info / Details: metadata + preview. Available
+                            // for base-listing rows AND wrapper-tree rows (files
+                            // inside a .sit / .toast / disk-image wrapper), which
+                            // resolve through the mounted wrapper filesystem.
+                            // Needs real data, so a not-yet-applied add is excluded.
+                            if !matches!(row.kind, RowKind::PendingAdd)
                                 && ui.button("File Info / Details...").clicked()
                             {
                                 m_info = Some(row.name.clone());

--- a/src/model/commander_ops.rs
+++ b/src/model/commander_ops.rs
@@ -560,6 +560,20 @@ pub enum HostCopyJob {
         entries: Vec<FileEntry>,
         dest_dir: PathBuf,
     },
+    /// Export image-volume `entries` to the host in `format` — loose files / a
+    /// per-file-compressed tree into a folder, or one tar/zip/sit archive file.
+    /// `dest` is the folder or the archive file per `format.is_single_file()`.
+    /// Boxed to keep the enum's variants close in size.
+    ExportSelection(Box<ExportJob>),
+}
+
+/// Payload for [`HostCopyJob::ExportSelection`].
+pub struct ExportJob {
+    pub source: StageSource,
+    pub entries: Vec<FileEntry>,
+    pub dest: PathBuf,
+    pub format: crate::fs::export_selection::ExportFormat,
+    pub fork_mode: ResourceForkMode,
 }
 
 /// Shared state between the GUI and the [`spawn_host_copy`] worker.
@@ -632,6 +646,68 @@ fn run_host_copy(job: HostCopyJob, status: &Arc<Mutex<HostCopyStatus>>) -> Resul
             }
             copy_host_entries_to_host(&entries, &dest_dir, status)
         }
+        HostCopyJob::ExportSelection(job) => run_export(*job, status),
+    }
+}
+
+fn run_export(job: ExportJob, status: &Arc<Mutex<HostCopyStatus>>) -> Result<usize> {
+    use crate::fs::export_selection::{export_to_file, export_to_folder};
+    let ExportJob {
+        source,
+        entries,
+        dest,
+        format,
+        fork_mode,
+    } = job;
+    let mut fs = source.open()?;
+    let (files_total, bytes_total) = scan_image_entries(fs.as_mut(), &entries)?;
+    if let Ok(mut g) = status.lock() {
+        g.files_total = files_total;
+        g.bytes_total = bytes_total;
+    }
+    let ps = Arc::clone(status);
+    let progress = move |cur: &str, done: usize, bytes: u64| {
+        if let Ok(mut g) = ps.lock() {
+            g.current_file = cur.to_string();
+            g.copied = done;
+            g.bytes_done = bytes;
+        }
+    };
+    let cs = Arc::clone(status);
+    let cancelled = move || cs.lock().map(|g| g.cancel_requested).unwrap_or(false);
+    let summary = if format.is_single_file() {
+        export_to_file(fs.as_mut(), &entries, &dest, format, &progress, &cancelled)?
+    } else {
+        export_to_folder(
+            fs.as_mut(),
+            &entries,
+            &dest,
+            format,
+            fork_mode,
+            &progress,
+            &cancelled,
+        )?
+    };
+    Ok(summary.files)
+}
+
+/// Export `entries` from an already-open (non-reopenable, e.g. wrapper-mount)
+/// filesystem synchronously — the small/local fallback that mirrors the
+/// synchronous copy path. `dest` is a folder or an archive file per `format`.
+pub fn export_now(
+    fs: &mut dyn Filesystem,
+    entries: &[FileEntry],
+    dest: &Path,
+    format: crate::fs::export_selection::ExportFormat,
+    fork_mode: ResourceForkMode,
+) -> Result<crate::fs::export_selection::ExportSummary> {
+    use crate::fs::export_selection::{export_to_file, export_to_folder};
+    let noprog = |_: &str, _: usize, _: u64| {};
+    let never = || false;
+    if format.is_single_file() {
+        export_to_file(fs, entries, dest, format, &noprog, &never)
+    } else {
+        export_to_folder(fs, entries, dest, format, fork_mode, &noprog, &never)
     }
 }
 

--- a/src/model/commander_ops.rs
+++ b/src/model/commander_ops.rs
@@ -24,7 +24,9 @@ use crate::fs::filesystem::Filesystem;
 use crate::fs::fork_export::{export_file_with_fork, safe_name};
 use crate::fs::resource_fork::{ImportedResourceFork, ResourceForkMode};
 use crate::model::browse_session::BrowseSession;
+use crate::model::commander_descend::DescendKind;
 use crate::model::edit_queue::{apply_edit, StagedEdit};
+use crate::model::wrapper_tree::{PreparedMount, WrapperSource, WrapperTree};
 
 /// Apply `edits` to the source described by `session`, in order.
 ///
@@ -201,6 +203,85 @@ impl StageSource {
             StageSource::Reopen(recipe) => recipe.open(),
         }
     }
+}
+
+/// How a wrapper-open worker gets the wrapper file's bytes to mount. Materializing
+/// a large `.toast` / `.chd` / `.iso` and probing it can take seconds, so the
+/// pane runs this off the UI thread behind a spinner ([`spawn_wrapper_open`]).
+pub enum WrapperOpenPlan {
+    /// A host file — opened by its real path (no extraction; also the only form
+    /// multi-file optical formats like bin/cue can use).
+    HostPath(PathBuf),
+    /// Extract the wrapper file from a reopenable enclosing source (a local
+    /// image session, a remote image, or a Mac archive), then mount it. Boxed —
+    /// a `StageSource` + `FileEntry` dwarfs the other variants.
+    Extract(Box<WrapperExtract>),
+    /// The wrapper bytes, already pulled off a non-reopenable enclosing layer on
+    /// the UI thread; the worker still owns the materialize + probe + open.
+    Bytes(Vec<u8>),
+}
+
+/// The reopenable source + wrapper entry for a [`WrapperOpenPlan::Extract`].
+pub struct WrapperExtract {
+    pub base: StageSource,
+    pub entry: FileEntry,
+}
+
+/// Progress + result of an off-thread wrapper open. `result` carries a
+/// [`PreparedMount`] to install, or a short error string.
+#[derive(Default)]
+pub struct WrapperOpenStatus {
+    pub phase: String,
+    pub finished: bool,
+    pub result: Option<std::result::Result<PreparedMount, String>>,
+}
+
+/// Open a wrapper (`file_name`, classified as `kind`) off the UI thread. The
+/// pane polls the returned handle each frame, shows a spinner with `phase`, and
+/// installs the [`PreparedMount`] via `WrapperTree::install_prepared` on finish.
+pub fn spawn_wrapper_open(
+    plan: WrapperOpenPlan,
+    kind: DescendKind,
+    file_name: String,
+) -> Arc<Mutex<WrapperOpenStatus>> {
+    let status = Arc::new(Mutex::new(WrapperOpenStatus {
+        phase: "Reading...".to_string(),
+        finished: false,
+        result: None,
+    }));
+    let st = Arc::clone(&status);
+    thread::spawn(move || {
+        let result = run_wrapper_open(plan, kind, file_name, &st);
+        if let Ok(mut g) = st.lock() {
+            g.result = Some(result);
+            g.finished = true;
+        }
+    });
+    status
+}
+
+fn run_wrapper_open(
+    plan: WrapperOpenPlan,
+    kind: DescendKind,
+    file_name: String,
+    status: &Arc<Mutex<WrapperOpenStatus>>,
+) -> std::result::Result<PreparedMount, String> {
+    let source = match plan {
+        WrapperOpenPlan::HostPath(path) => WrapperSource::Path(path),
+        WrapperOpenPlan::Bytes(bytes) => WrapperSource::Bytes(bytes),
+        WrapperOpenPlan::Extract(ex) => {
+            let WrapperExtract { base, entry } = *ex;
+            let mut fs = base.open().map_err(|e| format!("{e:#}"))?;
+            let mut buf = Vec::new();
+            fs.write_file_to(&entry, &mut buf)
+                .map_err(|e| format!("reading '{}': {e}", entry.name))?;
+            WrapperSource::Bytes(buf)
+        }
+    };
+    if let Ok(mut g) = status.lock() {
+        g.phase = "Opening...".to_string();
+    }
+    WrapperTree::prepare(source, &file_name, kind).map_err(|e| format!("{e:#}"))
 }
 
 /// Off-thread [`stage_copy`]: reopens the source on a worker, extracts each file

--- a/src/model/wrapper_tree.rs
+++ b/src/model/wrapper_tree.rs
@@ -74,6 +74,14 @@ struct Mount {
     reopen: Option<commander_descend::ReopenRecipe>,
 }
 
+/// A wrapper mount built off the UI thread (all fields `Send`), ready to install
+/// into a [`WrapperTree`]. Opaque so a worker can build it via
+/// [`WrapperTree::prepare`] without touching a live tree.
+pub struct PreparedMount {
+    mount: Mount,
+    note: Option<String>,
+}
+
 /// One visible row produced by the tree walk (a descendant of an expanded
 /// wrapper — base rows come from the pane's `DirListing`, not from here).
 #[derive(Clone)]
@@ -156,6 +164,31 @@ impl WrapperTree {
         }
         self.expanded.insert(node_id.to_string());
         Ok(())
+    }
+
+    /// Build a wrapper mount from `source` on the *calling* thread. This is the
+    /// expensive part of an expand — materializing a large image to a temp file,
+    /// probing its partitions, and opening the on-disc filesystem — so a pane
+    /// runs it on a worker (everything here is `Send`) and installs the result
+    /// with [`install_prepared`](Self::install_prepared) when it finishes.
+    pub fn prepare(
+        source: WrapperSource,
+        file_name: &str,
+        kind: DescendKind,
+    ) -> Result<PreparedMount> {
+        let (mount, note) = open_mount(source, file_name, kind)?;
+        Ok(PreparedMount { mount, note })
+    }
+
+    /// Install a [`PreparedMount`] built off-thread under `node_id` and mark the
+    /// node expanded. Returns its note (e.g. a multi-volume image fallback).
+    pub fn install_prepared(&mut self, node_id: &str, prepared: PreparedMount) -> Option<String> {
+        self.mounts.insert(node_id.to_string(), prepared.mount);
+        if let Some(n) = &prepared.note {
+            self.notes.insert(node_id.to_string(), n.clone());
+        }
+        self.expanded.insert(node_id.to_string());
+        prepared.note
     }
 
     /// Expand a folder node (its enclosing wrapper is already mounted).


### PR DESCRIPTION
## Summary

Commander Mode gains a full **export pipeline** plus several browse-quality fixes (6 commits).

### Export as — any output shape
- New GUI-free, `Filesystem`-generic **export-selection engine** (`src/fs/export_selection.rs`) that writes a Commander selection to the host in eight shapes: loose files (resource forks via a chosen container), gzip/zstd-each, tar / tar.gz / tar.zst, zip (data forks + AppleDouble `__MACOSX/._name` sidecars for Mac forks), and StuffIt `.sit` (forks + type/creator native). All formats reuse deps already in the tree (tar, zip, flate2, the selected zstd backend, the in-crate StuffIt writer) — none are feature-gated. Progress + cancel thread through every format.
- **BinHex (`.hqx`)** and **Mac Archive (`.mar`)** added as export targets — both were writable in the tree but not previously offered/discoverable.
- Wired into Commander: an **"Export as" dropdown** in the middle column (the fork-container combo is relabeled "Forks as:" and enabled only for Loose files) plus a per-row right-click **"Export as" submenu**. Single-file formats prompt for an archive name; folder formats for a directory. Exports run on the existing host-copy worker + progress modal via `HostCopyJob::ExportSelection`.

### Wrapper / pane fixes
- **Large wrappers open off-thread** with a spinner. Expanding a wrapper row (`.toast`/`.iso`/`.bincue`/`.chd`, or one nested in a `.sit`) was fully synchronous — a 422 MB StuffIt-wrapped disc froze the app for minutes. The materialize + probe + open now runs on a worker (`commander_ops::spawn_wrapper_open`), polled each frame; the listing stays visible. Nested/folder expands stay synchronous (small, local).
- **File Info / Details** now works for files browsed *inside* an expanded wrapper — resolved through the mounted wrapper filesystem; metadata editors are suppressed since wrapper contents are read-only (copy out, don't edit).
- **Read-only panes** get a "Read-only" badge, and the disabled copy button's hover explains why (Mac archive / backup folder / remote host folder). New `is_read_only()` / `readonly_reason()` helpers centralize the medium check.

## Testing
Round-trip tests parse emitted `.hqx` / `.mar` / tar.gz / zip / sit back to the original data fork; a Session-sourced tar.gz export was verified end-to-end with live progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
