### PR TITLE
feat(partition): parse the Sun disk label (SMI VTOC) for SPARC Solari…

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,7 @@ PC Engine CD, CD32, GameCube, Wii, CD-i, and 3DO.
 | APM    | Yes   | Yes  | Apple Partition Map (68k / PowerPC Macs). |
 | RDB    | Yes   | Bootable flag only | Amiga `RDSK`. Full RDB editing deferred until the DosEnv geometry story is settled. |
 | SGI    | Yes   | Yes  | SGI Volume Header (IRIX). 16 fixed slots; checksum recomputed on every write; geometry (`vh_dp`) preserved across edits. `rb-cli new hd sgi-efs` synthesizes a dvh + EFS-root hard disk from scratch (IRIX 5.3-6.5). |
+| Sun    | Yes   | No (browse) | Sun disk label / SMI VTOC (SPARC Solaris / SunOS). 8 big-endian slices (magic `0xDABE`), geometry-derived offsets; the whole-disk "backup" slice is excluded from the list. Surfaces the UFS slices to the existing big-endian-SPARC UFS reader (browse / inspect / extract). Parser cross-validated against `fdisk`/`sfdisk`; full-disk backup + label editing are future work. |
 | None (superfloppy) | Yes — auto-detects the filesystem at sector 0 (FAT / HFS / HFS+ / Apple DOS 3.3 / CBM DOS / Atari DOS / RS-DOS / OS-9 RBF / DragonDOS / Acorn DFS / ADFS / TR-DOS / TI-99 / QDOS / Human68k / Alto BFS / Pilot/Cedar / Apple Lisa FS / …) | — | Standard floppy / disk sizes are recognised even without a partition table. Xerox Alto packs (`.pdi` / `.bfs` / CopyDisk / Salto `.dsk`), Pilot/Cedar PDIs (`fsFamily=2`), Dwarf 6085 `.zdisk` images, and tag-bearing Apple Lisa DiskCopy 4.2 / DART disks are detected by content and presented as a single browsable volume. |
 
 The Clonezilla image format is also parsed as a source (MBR, GPT, partclone

--- a/docs/new-additional-filesystems.md
+++ b/docs/new-additional-filesystems.md
@@ -17,12 +17,25 @@ read-first cases (ZFS). Every write path is validated against an independent
   `scripts/trdos-oracle.py`, `scripts/ti99-oracle.py`.
 
 ## Priority order
-1. **OS/2 — HPFS**
+1. **OS/2 — HPFS** — DONE (full quartet: `src/fs/hpfs.rs`)
 2. **Atari 8-bit — SpartaDOS / MyDOS / DOS 3** (extends existing `src/fs/atari_dos.rs`)
-3. **ZFS** (read-first)
+3. ~~**ZFS** (read-first)~~ — **DROPPED.** ZFS is a *pool*, not a single-disk
+   filesystem; a multi-disk pool can't be one `.img` at all, so only the
+   single-disk-pool sliver would ever fit rusty-backup's model — and even that
+   carries the full pooling machinery (MOS/DSL/DMU/block-pointers/compression/
+   CoW) for browse-only value on a modern (Solaris 11+, 2011) FS the retro
+   audience rarely has. The preservation-worthy Sun disks (SunOS 4 → Solaris 10)
+   are **UFS on a Sun disk label**, which we already read — see the **Sun disk
+   label (SMI VTOC)** work below, done in its place (`src/partition/sun.rs`).
 4. TRSDOS / LDOS / NEWDOS (TRS-80)
-5. Sedoric / Oric DOS (Oric)
+5. **Sedoric / Oric DOS (Oric)** — Jasmin variant DONE (`src/fs/oric.rs`); Sedoric pending
 6. N88-BASIC (NEC PC-8801)
+
+**Also shipped (Sun-lineage, replaces ZFS):** Sun disk label / SMI VTOC
+partition scheme (`src/partition/sun.rs`) — parses the 8 big-endian slices on a
+SPARC Solaris / SunOS disk image and routes them to the existing UFS reader
+(browse / inspect / extract). Spec = local kernel `block/partitions/sun.c`;
+oracle = `fdisk`/`sfdisk` (non-sudo). Full-disk backup + label editing deferred.
 
 ---
 
@@ -74,7 +87,12 @@ read-first cases (ZFS). Every write path is validated against an independent
 
 ---
 
-## 3. ZFS (read-first) — PRIORITY 3
+## 3. ZFS (read-first) — ~~PRIORITY 3~~ DROPPED
+> **Dropped** — see the Priority-order note above. ZFS is a pool, not a
+> single-disk filesystem (model conflict), it's browse-only, and it's a modern
+> (Solaris 11+) FS the retro audience rarely has. Replaced by the **Sun disk
+> label (SMI VTOC)** parser, which unlocks the *actually* common Sun disk:
+> UFS on a Sun-labeled SPARC image. The notes below are retained for reference.
 - **Systems / era:** Solaris/OpenSolaris/illumos, FreeBSD, Linux (OpenZFS). The
   Sun → Oracle NAS/workstation FS.
 - **Why it matters:** Workstation & NAS image preservation; biggest Oracle-lineage gap.

--- a/src/backup/mod.rs
+++ b/src/backup/mod.rs
@@ -929,6 +929,22 @@ fn run_backup_inner(
             );
             bail!("backing up SGI disks is not yet supported (browse only)");
         }
+        PartitionTable::Sun(label) => {
+            // Mirror the SGI sidecar: record the slice layout in sun.json, but
+            // defer the per-slice data backup (the data path needs Sun-label
+            // sizing). Browse / inspect / extract already work via the slice
+            // list + the existing UFS reader.
+            let json = serde_json::to_string_pretty(label)
+                .context("failed to serialize Sun disk label to JSON")?;
+            std::fs::write(backup_folder.join("sun.json"), json)
+                .context("failed to write sun.json")?;
+            log(
+                &progress,
+                LogLevel::Info,
+                "Exported Sun disk label (sun.json) — partition data backup not yet supported",
+            );
+            bail!("backing up Sun-labeled disks is not yet supported (browse only)");
+        }
         PartitionTable::Ahdi(table) => {
             // Mirror the RDB / SGI sidecar shape: emit ahdi.json so a future
             // restore knows the AHDI primary slots, XGM chain, and disk-size

--- a/src/backup/single_file_chd.rs
+++ b/src/backup/single_file_chd.rs
@@ -1977,6 +1977,11 @@ fn build_patched_head_segments(
                 "assemble_from_staging: SGI Volume Header sources are not supported (browse only)"
             );
         }
+        PartitionTable::Sun(_) => {
+            anyhow::bail!(
+                "assemble_from_staging: Sun disk-label sources are not supported (browse only)"
+            );
+        }
         PartitionTable::Ahdi(_) => {
             anyhow::bail!(
                 "assemble_from_staging: AHDI sources are not yet supported by single-file CHD"

--- a/src/partition/alignment.rs
+++ b/src/partition/alignment.rs
@@ -66,6 +66,7 @@ pub fn detect_alignment(table: &PartitionTable) -> PartitionAlignment {
         PartitionTable::Apm(_)
         | PartitionTable::Rdb(_)
         | PartitionTable::Sgi(_)
+        | PartitionTable::Sun(_)
         | PartitionTable::Ahdi(_)
         | PartitionTable::X68k { .. }
         | PartitionTable::None { .. }

--- a/src/partition/editor.rs
+++ b/src/partition/editor.rs
@@ -202,6 +202,9 @@ pub fn apply_edits(
         PartitionTable::X68k { .. } => {
             bail!("X68000 partition-table editing is not yet implemented")
         }
+        PartitionTable::Sun(_) => {
+            bail!("Sun disk-label editing is not yet implemented (read / browse / back up only)")
+        }
         PartitionTable::None { .. } => bail!("cannot edit partition table on a superfloppy"),
         PartitionTable::Dsd { .. } => {
             bail!("cannot edit partition table on a double-sided DFS (.dsd) image")

--- a/src/partition/mod.rs
+++ b/src/partition/mod.rs
@@ -8,6 +8,7 @@ pub mod rdb;
 pub mod resize;
 pub mod sgi;
 pub mod sgi_hdd_builder;
+pub mod sun;
 pub mod x68k;
 pub mod x68k_hdd_builder;
 pub mod x68k_ipl;
@@ -21,6 +22,7 @@ use gpt::Gpt;
 use mbr::Mbr;
 use rdb::{Rdb, RDSK_SIGNATURE};
 use sgi::{SgiVolumeHeader, SGI_TYPE_BYTE_EFS, SGI_TYPE_BYTE_XFS, SGI_VOLHDR_MAGIC};
+use sun::SunDiskLabel;
 use x68k::X68kPartitionTable;
 
 pub use alignment::{detect_alignment, AlignmentType, PartitionAlignment};
@@ -41,6 +43,9 @@ pub enum PartitionTable {
     /// plus a volume directory of standalone executables (`sash`, `ide`,
     /// `/unix`); see `src/partition/sgi.rs`.
     Sgi(SgiVolumeHeader),
+    /// Sun disk label (SMI VTOC) — SPARC Solaris / SunOS disks. 8 slices,
+    /// big-endian, magic `0xDABE` at byte 508; see `src/partition/sun.rs`.
+    Sun(SunDiskLabel),
     /// Atari HD File System Driver — MBR-equivalent for Atari ST / TT / Falcon
     /// hard-disk images. 4 primary slots + XGM extended chains, big-endian,
     /// no boot signature; see `src/partition/atari.rs`.
@@ -654,6 +659,14 @@ impl PartitionTable {
             return Err(SgiVolumeHeader::parse(&mbr_data).unwrap_err());
         }
 
+        // Sun disk label (SPARC Solaris / SunOS): magic 0xDABE at byte 508 plus
+        // a valid XOR checksum. Checked before MBR — the magic sits at a
+        // different offset than the MBR 0xAA55 (byte 510) and the checksum
+        // makes a false positive on a real MBR effectively impossible.
+        if SunDiskLabel::detect(&mbr_data) {
+            return Ok(PartitionTable::Sun(SunDiskLabel::parse(&mbr_data)?));
+        }
+
         // Check for APM (Driver Descriptor Record signature 0x4552 at offset 0)
         let ddr_sig = u16::from_be_bytes([mbr_data[0], mbr_data[1]]);
         if ddr_sig == 0x4552 {
@@ -1005,6 +1018,28 @@ impl PartitionTable {
                     })
                     .collect()
             }
+            PartitionTable::Sun(label) => label
+                .browsable_slices()
+                .map(|(i, s)| PartitionInfo {
+                    index: i,
+                    // Slices are UFS on Solaris/SunOS; leave the type byte at 0
+                    // so `open_filesystem` auto-detects (finds the UFS super
+                    // block, big-endian SPARC variant included). Swap / other
+                    // slices simply won't resolve to a browsable filesystem.
+                    type_name: format!("Sun {} (UFS?)", s.tag_name()),
+                    partition_type_byte: 0,
+                    start_lba: s.start_sector,
+                    start_byte: None,
+                    size_bytes: s.size_bytes(),
+                    bootable: false,
+                    is_logical: false,
+                    is_extended_container: false,
+                    partition_type_string: None,
+                    hfs_block_size: None,
+                    rdb_part_block: None,
+                    drv_name: None,
+                })
+                .collect(),
             PartitionTable::Rdb(rdb) => rdb
                 .partitions
                 .iter()
@@ -1222,6 +1257,7 @@ impl PartitionTable {
             PartitionTable::Apm(_) => "APM",
             PartitionTable::Rdb(_) => "RDB",
             PartitionTable::Sgi(_) => "SGI",
+            PartitionTable::Sun(_) => "Sun",
             PartitionTable::Ahdi(_) => "AHDI",
             PartitionTable::X68k { .. } => "X68k",
             PartitionTable::None { .. } => "None",
@@ -1238,6 +1274,7 @@ impl PartitionTable {
             PartitionTable::Apm(_)
             | PartitionTable::Rdb(_)
             | PartitionTable::Sgi(_)
+            | PartitionTable::Sun(_)
             | PartitionTable::Ahdi(_)
             | PartitionTable::X68k { .. }
             | PartitionTable::None { .. }

--- a/src/partition/sun.rs
+++ b/src/partition/sun.rs
@@ -1,0 +1,406 @@
+//! Sun disk label (SMI VTOC) — the partition scheme SPARC Solaris / SunOS
+//! disks use instead of MBR/GPT.
+//!
+//! A single 512-byte label at sector 0 describes disk geometry and up to **8
+//! slices** (`{start_cylinder, num_sectors}`). All multi-byte fields are
+//! big-endian. This unlocks reading real Sun SPARC disk images — the UFS
+//! driver (`src/fs/ufs.rs`, big-endian SPARC variant included) is already in
+//! place; this is the missing piece that tells it where the slices live.
+//!
+//! Layout (from the Linux kernel `block/partitions/sun.c`, the reference this
+//! is modeled on and — via `fdisk`/`sfdisk` — validated against):
+//! - `info[128]` @0, VTOC block @128 (`version` be32, `volume[8]`, `nparts`
+//!   be16, then 8 × `{id, flags}` be16 pairs, `sanity` be32 = `0x600DDEEE`),
+//! - geometry: `ntrks` (heads) be16 @436, `nsect` (sectors/track) be16 @438;
+//!   sectors-per-cylinder = `ntrks * nsect`,
+//! - `partitions[8]` @444: each `{start_cylinder be32, num_sectors be32}`; a
+//!   slice's start sector = `start_cylinder * spc`,
+//! - `magic` be16 @508 = `0xDABE`, `csum` be16 @510 (XOR of all 256 words = 0).
+//!
+//! Slice **tag 5** (`SUN_WHOLE_DISK`, conventionally slice 2 "backup") spans
+//! the entire disk and overlaps the real slices, so it is skipped from the
+//! browse list — exactly like the SGI VOLHDR/VOLUME disk-wide wrappers.
+
+use byteorder::{BigEndian, ByteOrder};
+use serde::{Deserialize, Serialize};
+
+use crate::error::RustyBackupError;
+
+/// Magic at byte 508 of the 512-byte label (big-endian).
+pub const SUN_LABEL_MAGIC: u16 = 0xDABE;
+/// VTOC sanity value at offset 188 (big-endian) when the tag table is valid.
+pub const SUN_VTOC_SANITY: u32 = 0x600D_DEEE;
+/// Partition tag for the whole-disk "backup" slice (overlaps everything).
+pub const SUN_TAG_WHOLE_DISK: u16 = 5;
+
+const LABEL_SIZE: usize = 512;
+const N_SLICES: usize = 8;
+
+/// One Sun slice, resolved to absolute sectors.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct SunSlice {
+    /// Cylinder-relative start (as stored on disk).
+    pub start_cylinder: u32,
+    /// Absolute start sector = `start_cylinder * sectors_per_cylinder`.
+    pub start_sector: u64,
+    /// Length in 512-byte sectors.
+    pub num_sectors: u32,
+    /// VTOC partition tag (`id`), when the VTOC is valid; else 0.
+    pub tag: u16,
+    /// VTOC flags (bit 0 = unmountable, bit 1 = read-only), when valid.
+    pub flags: u16,
+}
+
+impl SunSlice {
+    pub fn is_empty(&self) -> bool {
+        self.num_sectors == 0
+    }
+    pub fn is_whole_disk(&self) -> bool {
+        self.tag == SUN_TAG_WHOLE_DISK
+    }
+    pub fn size_bytes(&self) -> u64 {
+        self.num_sectors as u64 * 512
+    }
+    pub fn start_offset(&self) -> u64 {
+        self.start_sector * 512
+    }
+    /// Plain-ASCII name for the VTOC tag (no Unicode glyphs).
+    pub fn tag_name(&self) -> &'static str {
+        match self.tag {
+            0 => "unassigned",
+            1 => "boot",
+            2 => "root",
+            3 => "swap",
+            4 => "usr",
+            5 => "backup",
+            6 => "stand",
+            7 => "var",
+            8 => "home",
+            9 => "altsctr",
+            10 => "cache",
+            11 => "reserved",
+            _ => "slice",
+        }
+    }
+}
+
+/// A parsed Sun disk label.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SunDiskLabel {
+    pub volume: String,
+    /// Data cylinder count.
+    pub ncyl: u16,
+    /// Tracks (heads) per cylinder.
+    pub ntrks: u16,
+    /// Sectors per track.
+    pub nsect: u16,
+    /// Sectors per cylinder = `ntrks * nsect`.
+    pub sectors_per_cylinder: u64,
+    /// True when the VTOC tag table validated (sanity + version + nparts).
+    pub vtoc_valid: bool,
+    pub slices: [SunSlice; N_SLICES],
+}
+
+impl SunDiskLabel {
+    /// Structural detector: magic `0xDABE` at offset 508 plus a valid label
+    /// checksum (XOR of all 256 big-endian words is zero).
+    pub fn detect(buf: &[u8]) -> bool {
+        if buf.len() < LABEL_SIZE {
+            return false;
+        }
+        if BigEndian::read_u16(&buf[508..510]) != SUN_LABEL_MAGIC {
+            return false;
+        }
+        checksum_ok(&buf[..LABEL_SIZE])
+    }
+
+    pub fn parse(buf: &[u8]) -> Result<Self, RustyBackupError> {
+        if buf.len() < LABEL_SIZE {
+            return Err(RustyBackupError::InvalidMbr(
+                "Sun label: buffer smaller than 512 bytes".into(),
+            ));
+        }
+        if BigEndian::read_u16(&buf[508..510]) != SUN_LABEL_MAGIC {
+            return Err(RustyBackupError::InvalidMbr(
+                "Sun label: bad magic (expected 0xDABE)".into(),
+            ));
+        }
+        if !checksum_ok(&buf[..LABEL_SIZE]) {
+            return Err(RustyBackupError::InvalidMbr(
+                "Sun label: checksum mismatch".into(),
+            ));
+        }
+
+        let version = BigEndian::read_u32(&buf[128..132]);
+        let volume = {
+            let raw = &buf[132..140];
+            let end = raw.iter().position(|&c| c == 0).unwrap_or(raw.len());
+            String::from_utf8_lossy(&raw[..end]).trim().to_string()
+        };
+        let nparts = BigEndian::read_u16(&buf[140..142]);
+        let sanity = BigEndian::read_u32(&buf[188..192]);
+
+        // Mirror the kernel's `use_vtoc` gate: either a fully sane VTOC, or the
+        // old-Linux-Sun convention where sanity/version/nparts are all zero.
+        let vtoc_valid = (sanity == SUN_VTOC_SANITY && version == 1 && nparts <= 8)
+            || (sanity == 0 && version == 0 && nparts == 0);
+
+        let ntrks = BigEndian::read_u16(&buf[436..438]);
+        let nsect = BigEndian::read_u16(&buf[438..440]);
+        let ncyl = BigEndian::read_u16(&buf[432..434]);
+        let spc = ntrks as u64 * nsect as u64;
+
+        let mut slices = [SunSlice {
+            start_cylinder: 0,
+            start_sector: 0,
+            num_sectors: 0,
+            tag: 0,
+            flags: 0,
+        }; N_SLICES];
+        for (i, slice) in slices.iter_mut().enumerate() {
+            let base = 444 + i * 8;
+            let start_cylinder = BigEndian::read_u32(&buf[base..base + 4]);
+            let num_sectors = BigEndian::read_u32(&buf[base + 4..base + 8]);
+            let (tag, flags) = if vtoc_valid {
+                let ib = 142 + i * 4;
+                (
+                    BigEndian::read_u16(&buf[ib..ib + 2]),
+                    BigEndian::read_u16(&buf[ib + 2..ib + 4]),
+                )
+            } else {
+                (0, 0)
+            };
+            *slice = SunSlice {
+                start_cylinder,
+                start_sector: start_cylinder as u64 * spc,
+                num_sectors,
+                tag,
+                flags,
+            };
+        }
+
+        Ok(SunDiskLabel {
+            volume,
+            ncyl,
+            ntrks,
+            nsect,
+            sectors_per_cylinder: spc,
+            vtoc_valid,
+            slices,
+        })
+    }
+
+    /// Non-empty slices in slice order, skipping the whole-disk "backup"
+    /// alias (tag 5), which overlaps the real slices.
+    pub fn browsable_slices(&self) -> impl Iterator<Item = (usize, &SunSlice)> {
+        self.slices
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| !s.is_empty() && !s.is_whole_disk())
+    }
+}
+
+/// The label checksum is a 16-bit XOR of all 256 big-endian words in the
+/// 512-byte label; a correct label (with its stored `csum`) XORs to zero.
+fn checksum_ok(label: &[u8]) -> bool {
+    let mut csum: u16 = 0;
+    for w in label.chunks_exact(2) {
+        csum ^= BigEndian::read_u16(w);
+    }
+    csum == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    fn have(tool: &str) -> bool {
+        Command::new(tool).arg("--help").output().is_ok()
+    }
+
+    /// Image bytes + `fdisk -l`'s `(start_sector, num_sectors)` per slice.
+    type SunFixture = (Vec<u8>, Vec<(u64, u64)>);
+
+    /// Build a Sun-labeled disk image with `sfdisk` (non-sudo, on a file) with
+    /// a known slice layout, and return its bytes + the parsed `fdisk -l`
+    /// (start_sector, num_sectors) per line for cross-checking.
+    fn sfdisk_sun_image() -> Option<SunFixture> {
+        if !have("sfdisk") || !have("fdisk") {
+            return None;
+        }
+        let dir = std::env::temp_dir();
+        let img = dir.join(format!("rb_sun_{}.img", std::process::id()));
+        // 100 MiB.
+        std::fs::write(&img, vec![0u8; 100 * 1024 * 1024]).ok()?;
+        // slice 1 (root), slice 2 (whole-disk backup), slice 3 (usr).
+        let script = "label: sun\n\
+             1 : start=0, size=40000, type=2\n\
+             2 : start=0, size=204800, type=5\n\
+             3 : start=40000, size=100000, type=4\n";
+        let ok = Command::new("sfdisk")
+            .arg(&img)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .and_then(|mut c| {
+                use std::io::Write;
+                c.stdin.take().unwrap().write_all(script.as_bytes())?;
+                c.wait()
+            })
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !ok {
+            let _ = std::fs::remove_file(&img);
+            return None;
+        }
+        // Parse `fdisk -l` for the authoritative Start/Sectors of each slice.
+        let out = Command::new("fdisk").arg("-l").arg(&img).output().ok()?;
+        let text = String::from_utf8_lossy(&out.stdout);
+        let mut rows = Vec::new();
+        for line in text.lines() {
+            if line.contains(&*img.to_string_lossy()) {
+                let cols: Vec<&str> = line.split_whitespace().collect();
+                // Device Start End Sectors Size Id Type...
+                if cols.len() >= 4 {
+                    if let (Ok(start), Ok(sectors)) =
+                        (cols[1].parse::<u64>(), cols[3].parse::<u64>())
+                    {
+                        rows.push((start, sectors));
+                    }
+                }
+            }
+        }
+        let bytes = std::fs::read(&img).ok();
+        let _ = std::fs::remove_file(&img);
+        bytes.map(|b| (b, rows))
+    }
+
+    #[test]
+    fn parses_sfdisk_sun_label_matching_fdisk() {
+        let Some((img, fdisk_rows)) = sfdisk_sun_image() else {
+            eprintln!("skipping: sfdisk/fdisk unavailable");
+            return;
+        };
+        assert!(SunDiskLabel::detect(&img[..512]), "detect failed");
+        let label = SunDiskLabel::parse(&img[..512]).expect("parse");
+
+        // Our non-empty slices, in order, must match fdisk's Start/Sectors.
+        let ours: Vec<(u64, u64)> = label
+            .slices
+            .iter()
+            .filter(|s| !s.is_empty())
+            .map(|s| (s.start_sector, s.num_sectors as u64))
+            .collect();
+        assert_eq!(
+            ours, fdisk_rows,
+            "slice geometry disagrees with fdisk -l (ours vs fdisk)"
+        );
+
+        // The whole-disk backup slice (tag 5) is present but excluded from browse.
+        assert!(label.slices.iter().any(|s| s.is_whole_disk()));
+        let browsable: Vec<u16> = label.browsable_slices().map(|(_, s)| s.tag).collect();
+        assert_eq!(browsable, vec![2, 4], "root + usr, backup excluded");
+    }
+
+    /// Wrap the real `test_ufs1.img` fixture in a Sun label (slice 0 at
+    /// cylinder 0, exactly how a Sun UFS root disk is laid out) and confirm the
+    /// parsed slice 0 lands the UFS super block where the driver expects it —
+    /// i.e. the label + slice offset correctly locate the filesystem.
+    #[test]
+    fn locates_ufs_filesystem_in_slice() {
+        if !have("sfdisk") || !have("zstd") {
+            eprintln!("skipping: sfdisk/zstd unavailable");
+            return;
+        }
+        let dir = std::env::temp_dir();
+        let ufs = dir.join(format!("rb_sunufs_ufs_{}.img", std::process::id()));
+        let disk = dir.join(format!("rb_sunufs_{}.img", std::process::id()));
+        let fixture = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/test_ufs1.img.zst"
+        );
+        let ok = Command::new("zstd")
+            .args(["-dfq", fixture, "-o"])
+            .arg(&ufs)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if !ok {
+            eprintln!("skipping: could not decompress fixture");
+            return;
+        }
+        let ufs_bytes = std::fs::read(&ufs).unwrap();
+        let spc: u64 = 16065; // sfdisk's default Sun geometry (255 * 63)
+        let cyls = ufs_bytes.len() as u64 / 512 / spc + 2;
+        std::fs::write(&disk, vec![0u8; (cyls * spc * 512) as usize]).unwrap();
+        // Place the UFS filesystem at offset 0.
+        {
+            use std::io::Write;
+            let mut f = std::fs::OpenOptions::new().write(true).open(&disk).unwrap();
+            f.write_all(&ufs_bytes).unwrap();
+        }
+        let slice_secs = ufs_bytes.len() as u64 / 512;
+        let slice_cyls = slice_secs.div_ceil(spc);
+        let script = format!(
+            "label: sun\n1 : start=0, size={}, type=2\n",
+            slice_cyls * spc
+        );
+        let applied = Command::new("sfdisk")
+            .arg(&disk)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .and_then(|mut c| {
+                use std::io::Write;
+                c.stdin.take().unwrap().write_all(script.as_bytes())?;
+                c.wait()
+            })
+            .map(|s| s.success())
+            .unwrap_or(false);
+
+        let result = (|| {
+            if !applied {
+                return None;
+            }
+            let img = std::fs::read(&disk).ok()?;
+            assert!(SunDiskLabel::detect(&img[..512]), "not detected as Sun");
+            let label = SunDiskLabel::parse(&img[..512]).ok()?;
+            let s0 = label.slices.iter().find(|s| !s.is_empty())?;
+            assert_eq!(s0.start_sector, 0, "slice 0 should start at cylinder 0");
+            // UFS1 super block is at slice_offset + 8192; its magic (0x00011954)
+            // sits at +1372 within the super block.
+            let magic_off = (s0.start_offset() + 8192 + 1372) as usize;
+            let magic = u32::from_le_bytes([
+                img[magic_off],
+                img[magic_off + 1],
+                img[magic_off + 2],
+                img[magic_off + 3],
+            ]);
+            assert_eq!(
+                magic, 0x0001_1954,
+                "UFS1 super block not where the slice points"
+            );
+            Some(())
+        })();
+
+        let _ = std::fs::remove_file(&ufs);
+        let _ = std::fs::remove_file(&disk);
+        if result.is_none() {
+            eprintln!("skipping: sfdisk could not apply the Sun label");
+        }
+    }
+
+    #[test]
+    fn rejects_non_sun() {
+        assert!(!SunDiskLabel::detect(&[0u8; 512]));
+        // Right magic, bad checksum.
+        let mut buf = [0u8; 512];
+        buf[508] = 0xDA;
+        buf[509] = 0xBE;
+        buf[0] = 0x01; // perturb so XOR != 0
+        assert!(!SunDiskLabel::detect(&buf));
+    }
+}


### PR DESCRIPTION
…s disks

Adds the Sun disk label — the partition scheme SPARC Solaris / SunOS disks use instead of MBR/GPT — so real Sun disk images finally open. The UFS driver (big-endian SPARC variant included) was already in place; the missing piece was telling it where the slices live.

src/partition/sun.rs parses the 512-byte label at sector 0: magic 0xDABE @508, the XOR-of-256-big-endian-words checksum, geometry (ntrks*nsect = sectors per cylinder), and 8 slices of {start_cylinder, num_sectors} with their VTOC tags. Wired into PartitionTable::detect (before MBR — different magic offset + the checksum rules out false positives) and partitions(): each non-empty slice is surfaced with type byte 0 so open_filesystem auto-detects the UFS super block, and the whole-disk "backup" slice (tag 5, conventionally slice 2) is excluded since it overlaps the real slices — exactly like the SGI VOLHDR/VOLUME wrappers. Backup + label editing are deferred (browse / inspect / extract land now), mirroring how SGI shipped.

Modeled on the local kernel block/partitions/sun.c and validated end-to-end against fdisk/sfdisk (non-sudo, on a file): the parser's slice geometry matches `fdisk -l` exactly, and an integration test wraps the real test_ufs1.img fixture in an sfdisk Sun label and confirms slice 0 lands the UFS super block where the driver expects it. Verified through rb-cli: `inspect` shows the Sun table + root/usr slices, and `ls img@1` browses the UFS filesystem inside the slice.

This lands in place of ZFS (Priority 3), which is dropped: ZFS is a pool, not a single-disk filesystem — a multi-disk pool can't be one .img, only the single-disk sliver would fit rusty-backup's model, and even that is browse-only value on a modern (Solaris 11+) FS the retro audience rarely has. The preservation-worthy Sun disks (SunOS 4 -> Solaris 10) are UFS on a Sun label, which this unlocks. Docs updated (README partition-tables table; docs/new-additional-filesystems.md priority order + ZFS-dropped rationale).