### PR TITLE
feat(optical): rip and browse DVD/Blu-ray discs from a physical drive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,7 +1044,7 @@ dependencies = [
 [[package]]
 name = "cd-da-reader"
 version = "0.4.1"
-source = "git+https://github.com/danifunker/rust-cd-da-reader?branch=file-backend-on-1.0#70f37567f37c05aa4c40578f0a353669f5bd2814"
+source = "git+https://github.com/danifunker/rust-cd-da-reader?branch=file-backend-on-1.0#5c3b8a4f9ccf583351b2600884c5836418fc5a08"
 dependencies = [
  "cc",
  "libc",
@@ -4302,13 +4302,14 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opticaldiscs"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d250b3d3580f584a145e6d47c9a44b48d7b41a93a8e71b86ef65f815a55b09c"
+checksum = "23983217ba7ba56e3b8a9bda8c3e7bf7dec9cc2ee279502063dc422f79f90906"
 dependencies = [
  "cue_sheet",
  "encoding_rs",
  "flate2",
+ "libc",
  "libchdman-rs",
  "log",
  "nod",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,14 @@ libchdman-rs = { version = "0.288.9", features = ["prebuilt"], optional = true }
 # (it's behind `gui`).
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "json", "rustls"], optional = true }
 webbrowser = { version = "1.0", optional = true }
-opticaldiscs = { version = "0.12.0", features = ["drives"], optional = true }
+# 0.13.0 is the floor, for two reasons:
+#   0.12.1 — macOS drive enumeration stopped looking only at IODVDDriveNub,
+#            which misses every USB-attached drive (those register as
+#            IO{CD,DVD,BD}Services), leaving the Optical tab's list empty.
+#   0.13.0 — `physical` / `open_physical`: reading a disc from the drive as flat
+#            cooked sectors, which is what makes DVD and Blu-ray work at all
+#            (the CD-only MMC ioctls fail on that media with ENOTTY).
+opticaldiscs = { version = "0.13.0", features = ["drives"], optional = true }
 cd-da-reader = { git = "https://github.com/danifunker/rust-cd-da-reader", branch = "file-backend-on-1.0", optional = true }
 # In-app CD-DA playback (Optical tab). Pinned <0.20 for the
 # OutputStream::try_default / Sink::try_new API used in gui/optical_audio.rs.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ What's in the MiSTer build:
   `optical rip --device /dev/sr0 --format iso|bincue`), plus `optical
   convert` (ISO ↔ BIN/CUE ↔ CD-CHD) and `optical browse` / `extract`. For
   devices with a CD/DVD drive such as the SuperStation One.
+  **Data DVD and Blu-ray discs rip too** — to `iso` only, since the raw
+  2352-byte sector formats `bincue` and CD-CHD need are CD-only concepts.
+  Console discs (Wii, GameCube, original Xbox) can *not* be ripped from a
+  standard drive: their media is proprietary and stock drive firmware will not
+  read it. Dump those on the console itself and open the resulting image here —
+  Wii/GameCube images (including NKit) and Xbox XDVDFS are fully supported.
 - **Machine-readable optical inspection:** `optical browse --format json`
   emits a deterministic, path-sorted file listing (add `--hash sha256` for
   per-file content hashes), and `optical info --format json` reports

--- a/src/cli/verbs/optical.rs
+++ b/src/cli/verbs/optical.rs
@@ -283,7 +283,15 @@ fn run_drives_verb(args: DrivesArgs) -> Result<()> {
     }
     log_stderr(format!("Found {} optical drive(s):", devices.len()));
     for d in &devices {
-        println!("{}  {}", d.cli_device_arg(), d.display_name);
+        // A connected drive with an empty tray has no device node to rip from
+        // yet (macOS only creates /dev/diskN once a disc is loaded). Print a "-"
+        // placeholder so the column never comes out blank, and say why.
+        let arg = d.cli_device_arg();
+        if arg.is_empty() {
+            println!("-  {}  (no disc)", d.display_name);
+        } else {
+            println!("{}  {}", arg, d.display_name);
+        }
     }
     Ok(())
 }

--- a/src/gui/optical_tab.rs
+++ b/src/gui/optical_tab.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use opticaldiscs::detect::DiscImageInfo;
@@ -403,6 +403,40 @@ impl OpticalTab {
                                 self.rip_devices.len()
                             ));
                         }
+
+                        // Eject the selected local drive. Remote drives are the
+                        // daemon's to control, and a drive with no disc has no
+                        // device path to act on.
+                        let ejectable = self
+                            .selected_drive_idx
+                            .and_then(|idx| self.rip_devices.get(idx))
+                            .filter(|d| !d.is_remote() && !d.device_path.is_empty())
+                            .map(|d| d.device_path.clone());
+                        ui.add_enabled_ui(ejectable.is_some(), |ui| {
+                            if ui
+                                .button("Eject")
+                                .on_disabled_hover_text(
+                                    "Select a local drive with a disc in it to eject.",
+                                )
+                                .clicked()
+                            {
+                                if let Some(path) = ejectable {
+                                    match rusty_backup::optical::source::eject_disc(
+                                        std::path::Path::new(&path),
+                                    ) {
+                                        Ok(()) => {
+                                            log.info(format!("Ejected {path}"));
+                                            // The disc is gone: drop anything
+                                            // still pointing at it, then re-scan
+                                            // so the drive shows as empty.
+                                            self.close_disc();
+                                            self.refresh_drives();
+                                        }
+                                        Err(e) => log.warn(format!("Eject failed: {e:#}")),
+                                    }
+                                }
+                            }
+                        });
                     });
                 }
                 SourceMode::ImageFile => {
@@ -460,7 +494,7 @@ impl OpticalTab {
                 }
                 if was_browsing && self.disc_info.is_some() {
                     if let Some(path) = self.get_browsable_path() {
-                        self.browse_view.open(&path);
+                        self.open_browse(&path);
                     }
                 }
             }
@@ -475,6 +509,15 @@ impl OpticalTab {
                 ui.label(format!("FS: {}", info.filesystem.display_name()));
                 if let Some(ref label) = info.volume_label {
                     ui.label(format!("Volume: {label}"));
+                }
+                // Physical media only: the drive's reported capacity, so the
+                // user can see what a full rip will cost before starting one.
+                if let Some(bytes) = info.media_size_bytes {
+                    ui.label(format!(
+                        "Size: {} ({} sectors)",
+                        rusty_backup::optical::browse_view::format_size(bytes),
+                        bytes / 2048
+                    ));
                 }
                 if let Some(g) = &info.game {
                     ui.label(format!(
@@ -495,7 +538,7 @@ impl OpticalTab {
                 ui.add_space(60.0);
                 if !self.browse_view.is_active() && ui.button("Browse Contents").clicked() {
                     if let Some(path) = self.get_browsable_path() {
-                        self.browse_view.open(&path);
+                        self.open_browse(&path);
                     }
                 }
                 if ui.button("Close Disc").clicked() {
@@ -735,6 +778,17 @@ impl OpticalTab {
         }
     }
 
+    /// Open the browse view against the current source, picking the
+    /// device-backed reader for a physical drive (see
+    /// [`OpticalDiscBrowseView::open_physical`]).
+    fn open_browse(&mut self, path: &Path) {
+        if self.source_mode == SourceMode::PhysicalDrive {
+            self.browse_view.open_physical(path);
+        } else {
+            self.browse_view.open(path);
+        }
+    }
+
     fn close_disc(&mut self) {
         self.browse_view.close();
         self.disc_info = None;
@@ -756,7 +810,17 @@ impl OpticalTab {
             None => return,
         };
 
-        match DiscImageInfo::open(&path) {
+        // A drive is not a file: `DiscImageInfo::open` sniffs a container format
+        // from the path and opens it as one, and on macOS the buffered
+        // /dev/diskN node is EBUSY while the disc is mounted. `open_physical`
+        // reads the raw node as flat cooked sectors instead, which is what a
+        // data CD / DVD / Blu-ray actually is.
+        let probe = match self.source_mode {
+            SourceMode::PhysicalDrive => DiscImageInfo::open_physical(&path),
+            SourceMode::ImageFile => DiscImageInfo::open(&path),
+        };
+
+        match probe {
             Ok(info) => {
                 log.info(format!(
                     "Detected disc: {} / {} {}",

--- a/src/model/optical_devices.rs
+++ b/src/model/optical_devices.rs
@@ -38,12 +38,21 @@ pub struct RipDevice {
 impl RipDevice {
     /// Label for a GUI pulldown: local shows `name (path)`; remote prefixes the
     /// daemon as `[host:port] name (path)`.
+    ///
+    /// A connected drive with an empty tray has no device node yet (macOS only
+    /// creates `/dev/diskN` once a disc is loaded), so it is labelled
+    /// `name (no disc)` rather than with an empty pair of parentheses.
     pub fn picker_label(&self) -> String {
+        let path = if self.device_path.is_empty() {
+            "no disc"
+        } else {
+            &self.device_path
+        };
         match &self.location {
-            DeviceLocation::Local => format!("{} ({})", self.display_name, self.device_path),
+            DeviceLocation::Local => format!("{} ({})", self.display_name, path),
             #[cfg(feature = "remote")]
             DeviceLocation::Remote { label, .. } => {
-                format!("[{}] {} ({})", label, self.display_name, self.device_path)
+                format!("[{}] {} ({})", label, self.display_name, path)
             }
         }
     }
@@ -173,5 +182,17 @@ mod tests {
             #[cfg(feature = "remote")]
             _ => panic!("expected a local target"),
         }
+    }
+
+    #[test]
+    fn empty_tray_drive_labels_as_no_disc() {
+        // macOS only publishes /dev/diskN once a disc is loaded, so a connected
+        // but empty drive arrives with no device path.
+        let d = RipDevice {
+            display_name: "HL-DT-ST DVDRAM GP65NW60".to_string(),
+            device_path: String::new(),
+            location: DeviceLocation::Local,
+        };
+        assert_eq!(d.picker_label(), "HL-DT-ST DVDRAM GP65NW60 (no disc)");
     }
 }

--- a/src/optical/browse_view.rs
+++ b/src/optical/browse_view.rs
@@ -33,6 +33,12 @@ struct ExtractionProgress {
 pub struct OpticalDiscBrowseView {
     disc_path: Option<PathBuf>,
     disc_info: Option<DiscImageInfo>,
+    /// True when `disc_path` is a drive's device node rather than an image file.
+    /// Every re-open has to go back through the device-backed reader: the
+    /// file-based one re-derives its reader from `disc_info.path`, which on macOS
+    /// is `EBUSY` while the disc is mounted — that silently produced empty
+    /// directories rather than an error.
+    physical: bool,
     /// Selected filesystem on a hybrid disc: `0` = the primary, `N` =
     /// `disc_info.hybrid_filesystems[N - 1]` (the Mac HFS side). Always `0` for
     /// an ordinary single-filesystem disc.
@@ -76,6 +82,7 @@ impl Default for OpticalDiscBrowseView {
         Self {
             disc_path: None,
             disc_info: None,
+            physical: false,
             selected_fs: 0,
             root: None,
             directory_cache: HashMap::new(),
@@ -97,15 +104,43 @@ impl Default for OpticalDiscBrowseView {
 }
 
 impl OpticalDiscBrowseView {
-    /// Open a disc image for browsing.
+    /// Open a disc image file for browsing.
     pub fn open(&mut self, path: &Path) {
+        self.open_source(path, false);
+    }
+
+    /// Open the disc in a physical drive for browsing.
+    ///
+    /// `path` is a device path (e.g. `/dev/disk6`), not an image file.
+    pub fn open_physical(&mut self, path: &Path) {
+        self.open_source(path, true);
+    }
+
+    /// Shared open path. `physical` selects the device-backed reader: a drive is
+    /// not a file, so the container sniffing in [`DiscImageInfo::open`] does not
+    /// apply to it, and on macOS the buffered `/dev/diskN` node is `EBUSY` while
+    /// the disc is mounted. The physical route reads the raw node as the flat run
+    /// of cooked sectors that a data CD / DVD / Blu-ray is.
+    fn open_source(&mut self, path: &Path, physical: bool) {
         self.close();
         self.disc_path = Some(path.to_path_buf());
+        self.physical = physical;
         self.selected_fs = 0;
 
-        match DiscImageInfo::open(path) {
+        let probe = if physical {
+            DiscImageInfo::open_physical(path)
+        } else {
+            DiscImageInfo::open(path)
+        };
+
+        match probe {
             Ok(info) => {
-                match open_disc_filesystem(&info) {
+                let opened = if physical {
+                    opticaldiscs::browse::open_physical_filesystem(path)
+                } else {
+                    open_disc_filesystem(&info)
+                };
+                match opened {
                     Ok(mut fs) => {
                         match fs.root() {
                             Ok(root) => {
@@ -152,6 +187,7 @@ impl OpticalDiscBrowseView {
 
     pub fn close(&mut self) {
         self.disc_path = None;
+        self.physical = false;
         self.disc_info = None;
         self.selected_fs = 0;
         self.root = None;
@@ -180,6 +216,15 @@ impl OpticalDiscBrowseView {
             .disc_info
             .as_ref()
             .ok_or_else(|| FilesystemError::Parse("no disc info available".into()))?;
+        if self.physical {
+            // A drive has no hybrid-filesystem selection to honour: the device
+            // reader always presents the primary volume.
+            let path = self
+                .disc_path
+                .as_ref()
+                .ok_or_else(|| FilesystemError::Parse("no device path available".into()))?;
+            return opticaldiscs::browse::open_physical_filesystem(path);
+        }
         if self.selected_fs == 0 {
             open_disc_filesystem(info)
         } else {
@@ -446,14 +491,21 @@ impl OpticalDiscBrowseView {
     }
 
     fn load_directory(&mut self, entry: &FileEntry) {
-        if let Ok(mut fs) = self.open_fs() {
-            match fs.list_directory(entry) {
-                Ok(entries) => {
-                    self.directory_cache.insert(entry.path.clone(), entries);
-                }
-                Err(e) => {
-                    self.error = Some(format!("Failed to read {}: {e}", entry.path));
-                }
+        // Report a failed re-open instead of dropping it: swallowing this made a
+        // directory that could not be read look simply empty.
+        let mut fs = match self.open_fs() {
+            Ok(fs) => fs,
+            Err(e) => {
+                self.error = Some(format!("Failed to reopen disc for {}: {e}", entry.path));
+                return;
+            }
+        };
+        match fs.list_directory(entry) {
+            Ok(entries) => {
+                self.directory_cache.insert(entry.path.clone(), entries);
+            }
+            Err(e) => {
+                self.error = Some(format!("Failed to read {}: {e}", entry.path));
             }
         }
     }
@@ -872,6 +924,10 @@ impl OpticalDiscBrowseView {
         let entry = entry.clone();
         let disc_path = self.disc_path.clone().unwrap();
         let resource_fork_mode = self.resource_fork_mode;
+        // The extraction thread re-opens the disc from scratch, so it needs the
+        // same device-vs-file distinction the UI thread makes — a file-based
+        // re-open of a drive is EBUSY while the disc is mounted.
+        let physical = self.physical;
 
         let progress = Arc::new(Mutex::new(ExtractionProgress {
             current_bytes: 0,
@@ -890,10 +946,21 @@ impl OpticalDiscBrowseView {
         std::thread::spawn(move || {
             let _wake = crate::os::wakelock::acquire("Rusty Backup: extract optical disc files");
             let result = (|| -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-                let info = DiscImageInfo::open(&disc_path)?;
+                let info = if physical {
+                    DiscImageInfo::open_physical(&disc_path)?
+                } else {
+                    DiscImageInfo::open(&disc_path)?
+                };
+                let reopen = || {
+                    if physical {
+                        opticaldiscs::browse::open_physical_filesystem(&disc_path)
+                    } else {
+                        open_disc_filesystem(&info)
+                    }
+                };
 
                 // Count files and bytes for progress
-                let mut counting_fs = open_disc_filesystem(&info)?;
+                let mut counting_fs = reopen()?;
                 let (total_files, total_bytes) = count_entry(&mut *counting_fs, &entry)?;
                 if let Ok(mut p) = progress.lock() {
                     p.total_files = total_files;
@@ -902,7 +969,7 @@ impl OpticalDiscBrowseView {
                 drop(counting_fs);
 
                 // Open a fresh filesystem for extraction
-                let mut fs = open_disc_filesystem(&info)?;
+                let mut fs = reopen()?;
                 extract_entry(&mut *fs, &entry, &dest, resource_fork_mode, &progress)?;
 
                 Ok(())
@@ -1194,7 +1261,7 @@ fn display_name(entry: &FileEntry) -> &str {
 }
 
 /// Human-friendly size string.
-fn format_size(bytes: u64) -> String {
+pub fn format_size(bytes: u64) -> String {
     match bytes {
         s if s < 1_024 => format!("{} B", s),
         s if s < 1_024 * 1_024 => format!("{:.1} KB", s as f64 / 1_024.0),

--- a/src/optical/rip.rs
+++ b/src/optical/rip.rs
@@ -197,11 +197,49 @@ pub fn run_rip(config: RipConfig, progress: Arc<Mutex<RipProgress>>) -> Result<(
     Ok(())
 }
 
+/// Open a locally-attached drive, picking the reader the medium actually needs.
+///
+/// `cd-da-reader` speaks MMC/SCSI pass-through, which is the only way to read a
+/// CD (2352-byte sectors, audio tracks, Mode 2 forms) but is *CD-only*: those
+/// commands fail on DVD and Blu-ray media — on macOS with `ENOTTY` from
+/// `DKIOCCDREADTOC`, before a single sector is read. So the pass-through reader
+/// is tried first and kept whenever it can see a TOC, and a DVD/BD falls through
+/// to [`PhysicalDiscSource`], which reads the medium as flat 2048-byte cooked
+/// sectors.
+///
+/// The TOC read is what discriminates, rather than asking the OS what media is
+/// loaded: it is the exact capability the rip depends on, so it cannot
+/// misclassify a disc the reader would then choke on.
+fn open_local_source(path: &str) -> Result<Box<dyn OpticalSource>> {
+    // Claim the drive once, up front, and hand it to whichever reader wins.
+    // Letting each reader claim for itself made a DVD unmount/claim/release/
+    // re-claim, since the CD reader is always constructed first to probe.
+    let claim = crate::optical::source::claim_drive(path);
+
+    match LocalCdReader::with_retry_unclaimed(path, Default::default()) {
+        Ok(mut reader) if reader.read_toc().is_ok() => {
+            reader.set_claim(claim);
+            return Ok(Box::new(reader));
+        }
+        Ok(_) => {
+            log::info!("{path}: no CD table of contents — treating as DVD/Blu-ray media");
+        }
+        Err(e) => {
+            log::info!("{path}: CD reader unavailable ({e:#}) — trying DVD/Blu-ray media");
+        }
+    }
+
+    let mut source = crate::optical::source::PhysicalDiscSource::open_unclaimed(path)
+        .with_context(|| format!("{path} could not be read as either CD or DVD/Blu-ray media"))?;
+    source.set_claim(claim);
+    Ok(Box::new(source))
+}
+
 /// Build the [`OpticalSource`] for this rip — a local drive or a network proxy
 /// to a remote daemon's drive (see `docs/remote_ripping.md`).
 fn open_optical_source(config: &RipConfig) -> Result<Box<dyn OpticalSource>> {
     match &config.device {
-        OpticalTarget::Local(path) => Ok(Box::new(LocalCdReader::open(path)?)),
+        OpticalTarget::Local(path) => Ok(open_local_source(path)?),
         #[cfg(feature = "remote")]
         OpticalTarget::Remote { conn, device_path } => {
             Ok(Box::new(crate::optical::source::RemoteCdReader::open(

--- a/src/optical/source.rs
+++ b/src/optical/source.rs
@@ -14,6 +14,34 @@ use std::path::Path;
 use anyhow::{bail, Context, Result};
 use cd_da_reader::{CdReader, ReadOptions, RetryConfig, SectorReadFormat, Toc};
 
+/// Exclusive-use guard on a locally-attached drive, held for as long as a source
+/// is open. Dropping it releases the claim.
+///
+/// Only macOS arbitrates access to a drive across processes (DiskArbitration);
+/// elsewhere this is inert, and a plain `Option<()>` keeps the field shape the
+/// same on every platform.
+#[cfg(target_os = "macos")]
+pub(crate) type DriveClaim = Option<crate::os::macos::DiskClaim>;
+#[cfg(not(target_os = "macos"))]
+pub(crate) type DriveClaim = Option<()>;
+
+/// Take exclusive use of `device_path` for the life of the returned guard, so
+/// nothing else on the system competes for the drive head during a read.
+///
+/// Never fails the caller: a drive that cannot be claimed is still perfectly
+/// readable, just shared. See [`crate::os::macos::claim_optical_disc`].
+pub(crate) fn claim_drive(device_path: &str) -> DriveClaim {
+    #[cfg(target_os = "macos")]
+    {
+        crate::os::macos::claim_optical_disc(device_path)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = device_path;
+        None
+    }
+}
+
 /// A source of optical-disc sectors. The three methods are the entire physical
 /// surface the rip pipeline needs, so an implementor can be a locally-attached
 /// drive or a network proxy without the rip/encode code knowing the difference.
@@ -35,6 +63,8 @@ pub struct LocalCdReader {
     inner: CdReader,
     device_path: String,
     retry: RetryConfig,
+    /// Held for the life of the reader; released on drop.
+    _claim: DriveClaim,
 }
 
 impl LocalCdReader {
@@ -46,14 +76,69 @@ impl LocalCdReader {
 
     /// Open `device_path` with an explicit retry policy.
     pub fn with_retry(device_path: &str, retry: RetryConfig) -> Result<Self> {
-        let inner = CdReader::open_path(device_path)
-            .with_context(|| format!("Failed to open drive: {device_path}"))?;
+        // Claim before opening: unmounting the disc out from under an open
+        // handle is a good way to get spurious I/O errors mid-read.
+        let claim = claim_drive(device_path);
+        let mut reader = Self::with_retry_unclaimed(device_path, retry)?;
+        reader._claim = claim;
+        Ok(reader)
+    }
+
+    /// Open without taking exclusive use, for a caller that already holds the
+    /// claim (or is only probing whether this reader can drive the medium at
+    /// all). Attach the claim afterwards with [`Self::set_claim`].
+    pub fn with_retry_unclaimed(device_path: &str, retry: RetryConfig) -> Result<Self> {
+        let inner = match CdReader::open_path(device_path) {
+            Ok(inner) => inner,
+            Err(e) => open_elevated_or_fail(device_path, e)?,
+        };
         Ok(Self {
             inner,
             device_path: device_path.to_string(),
             retry,
+            _claim: None,
         })
     }
+
+    /// Take ownership of an exclusive-use claim already held by the caller.
+    pub(crate) fn set_claim(&mut self, claim: DriveClaim) {
+        self._claim = claim;
+    }
+}
+
+/// Second chance at opening a drive the direct `open` was not allowed to touch.
+///
+/// On macOS this escalates through `authopen`, which shows the native
+/// authorization dialog and hands back a descriptor. It matters most in the GUI:
+/// a terminal usually already has Full Disk Access, so `rb-cli` opens the device
+/// on the first try and never lands here, while the app bundle does not and used
+/// to fail with no prompt at all. `cd-da-reader` opens `/dev/rdiskN` itself and
+/// has no escalation of its own, so without this the denial was terminal.
+///
+/// Any error other than a permission denial is passed straight through — a
+/// missing disc or a detached drive is not something a password can fix.
+fn open_elevated_or_fail(device_path: &str, err: cd_da_reader::CdReaderError) -> Result<CdReader> {
+    #[cfg(target_os = "macos")]
+    {
+        let denied = matches!(
+            &err,
+            cd_da_reader::CdReaderError::Io(io)
+                if io.kind() == std::io::ErrorKind::PermissionDenied
+        );
+        if denied {
+            let file =
+                crate::os::macos::authopen_optical_device(device_path).with_context(|| {
+                    format!(
+                        "Failed to open drive {device_path}: permission denied, and \
+                     requesting administrator access did not succeed. Granting \
+                     Rusty Backup Full Disk Access in System Settings > Privacy \
+                     & Security also fixes this."
+                    )
+                })?;
+            return Ok(CdReader::from_file(file));
+        }
+    }
+    Err(anyhow::Error::from(err)).with_context(|| format!("Failed to open drive: {device_path}"))
 }
 
 impl OpticalSource for LocalCdReader {
@@ -154,7 +239,7 @@ mod remote_source {
 pub use remote_source::RemoteCdReader;
 
 /// Eject the disc from the drive at `path` (OS-specific shell-out).
-fn eject_disc(path: &Path) -> Result<()> {
+pub fn eject_disc(path: &Path) -> Result<()> {
     #[cfg(target_os = "linux")]
     {
         let status = std::process::Command::new("eject")
@@ -196,4 +281,110 @@ fn eject_disc(path: &Path) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// [`OpticalSource`] for a **DVD or Blu-ray** in a physical drive.
+///
+/// The default [`LocalCdReader`] path issues MMC/SCSI pass-through commands,
+/// which are unavoidable for CD (a CD's sectors are 2352 bytes on the wire) but
+/// are *CD-only*: on macOS `DKIOCCDREADTOC` / `DKIOCCDREAD` against DVD or
+/// Blu-ray media fail with `ENOTTY`, so a DVD could not be ripped at all — the
+/// rip died before it even read a table of contents.
+///
+/// A data DVD/BD needs none of that. The drive presents it as a flat run of
+/// 2048-byte cooked sectors, so this source reads it through
+/// [`opticaldiscs::physical::PhysicalDisc`] and synthesises the single-data-track
+/// TOC the rip pipeline expects. Only `Mode1Cooked` reads are possible — the raw
+/// 2352-byte formats have no meaning on DVD/BD media, which is also why this
+/// source serves ISO output only and never BIN/CUE.
+pub struct PhysicalDiscSource {
+    /// `OpticalSource` takes `&self`, while `SectorReader` reads need `&mut`.
+    disc: std::sync::Mutex<opticaldiscs::physical::PhysicalDisc>,
+    device_path: String,
+    /// Medium length in 2048-byte sectors — becomes the TOC's lead-out.
+    sector_count: u32,
+    /// Held for the life of the reader; released on drop.
+    _claim: DriveClaim,
+}
+
+impl PhysicalDiscSource {
+    /// Open the disc in `device_path` as a flat cooked-sector medium.
+    ///
+    /// Fails if the medium's capacity can't be determined, since the rip needs a
+    /// sector count to know where the disc ends.
+    pub fn open(device_path: &str) -> Result<Self> {
+        // Claim before opening, so the unmount can't yank the disc out from
+        // under a live handle.
+        let claim = claim_drive(device_path);
+        let mut src = Self::open_unclaimed(device_path)?;
+        src._claim = claim;
+        Ok(src)
+    }
+
+    /// Take ownership of an exclusive-use claim already held by the caller.
+    pub(crate) fn set_claim(&mut self, claim: DriveClaim) {
+        self._claim = claim;
+    }
+
+    /// Open without taking exclusive use, for a caller that already holds the
+    /// claim. Attach it afterwards with [`Self::set_claim`].
+    pub fn open_unclaimed(device_path: &str) -> Result<Self> {
+        let disc = opticaldiscs::physical::PhysicalDisc::open(device_path)
+            .with_context(|| format!("Failed to open disc in {device_path}"))?;
+
+        let sectors = disc.sector_count().ok_or_else(|| {
+            anyhow::anyhow!("Could not determine the capacity of the disc in {device_path}")
+        })?;
+        let sector_count = u32::try_from(sectors)
+            .map_err(|_| anyhow::anyhow!("Disc in {device_path} is too large to address"))?;
+
+        Ok(Self {
+            disc: std::sync::Mutex::new(disc),
+            device_path: device_path.to_string(),
+            sector_count,
+            _claim: None,
+        })
+    }
+}
+
+impl OpticalSource for PhysicalDiscSource {
+    fn read_toc(&self) -> Result<Toc> {
+        // A data DVD/BD has no CD-style TOC: the whole medium is one data track
+        // starting at LBA 0, with the lead-out at the end of the medium.
+        Ok(Toc {
+            first_track: 1,
+            last_track: 1,
+            tracks: vec![cd_da_reader::Track {
+                number: 1,
+                start_lba: 0,
+                start_msf: cd_da_reader::lba_to_msf(0),
+                is_audio: false,
+            }],
+            leadout_lba: self.sector_count,
+        })
+    }
+
+    fn read_data_sectors(&self, lba: u32, count: u32, format: SectorReadFormat) -> Result<Vec<u8>> {
+        if format != SectorReadFormat::Mode1Cooked {
+            bail!(
+                "DVD/Blu-ray media can only be read as 2048-byte cooked sectors \
+                 ({format:?} is a CD-only raw format); rip to ISO instead"
+            );
+        }
+
+        let mut disc = self
+            .disc
+            .lock()
+            .map_err(|_| anyhow::anyhow!("disc reader lock was poisoned"))?;
+
+        // One seek + one read for the whole run. Reading sector-at-a-time here
+        // measured ~10 KB/s against a DVD-R — an optical drive charges seek and
+        // rotational latency per I/O, not per byte.
+        disc.read_sectors(u64::from(lba), count)
+            .with_context(|| format!("Failed to read {count} sectors at LBA {lba}"))
+    }
+
+    fn eject(&self) -> Result<()> {
+        eject_disc(Path::new(&self.device_path))
+    }
 }

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -6,6 +6,7 @@ use std::os::unix::io::FromRawFd;
 use std::path::{Path, PathBuf};
 use std::ptr::{self, NonNull};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 
@@ -555,6 +556,40 @@ unsafe extern "C-unwind" fn claim_release_deny(
 ///
 /// Non-fatal: returns `Ok(None)` if the claim fails.
 fn da_claim_disk(bsd_name: &str) -> Result<Option<DiskClaim>> {
+    // Fast path: the main run loop, which the GUI pumps. Short deadline — if
+    // nobody is pumping it (rb-cli, rb-cli tui), the callback will never arrive
+    // and waiting the full timeout just stalls the caller for nothing.
+    match da_claim_disk_on(bsd_name, RunLoopTarget::Main, Duration::from_secs(1)) {
+        Ok(Some(claim)) => return Ok(Some(claim)),
+        Ok(None) => {}
+        Err(e) => return Err(e),
+    }
+
+    // Fallback: schedule on *this* thread's run loop and pump it ourselves, so a
+    // binary with no main-loop pump still gets a real claim instead of silently
+    // running shared. The trade-off is that this loop is not pumped during the
+    // blocking reads that follow, so the release-denial callback cannot fire —
+    // another DA client could take the disk mid-read. That is strictly better
+    // than holding no claim at all, which is what the timeout used to leave us
+    // with.
+    log::debug!("DA: main run loop is not being pumped — claiming on this thread instead");
+    da_claim_disk_on(bsd_name, RunLoopTarget::Current, Duration::from_secs(5))
+}
+
+/// Which run loop a claim's callbacks are delivered on.
+#[derive(Clone, Copy, PartialEq)]
+enum RunLoopTarget {
+    /// The process main run loop — correct when something pumps it (the GUI).
+    Main,
+    /// The calling thread's run loop, pumped inline while awaiting the claim.
+    Current,
+}
+
+fn da_claim_disk_on(
+    bsd_name: &str,
+    target: RunLoopTarget,
+    timeout: Duration,
+) -> Result<Option<DiskClaim>> {
     let session =
         unsafe { DASession::new(None) }.context("failed to create DiskArbitration session")?;
 
@@ -568,9 +603,14 @@ fn da_claim_disk(bsd_name: &str) -> Result<Option<DiskClaim>> {
     }
     .context(format!("failed to create DADisk for {}", bsd_name))?;
 
-    // Schedule on the MAIN run loop so the release-denial callback fires
-    // even while the worker thread does blocking disk I/O.
-    let main_run_loop = CFRunLoop::main().context("failed to get main CFRunLoop")?;
+    // The main run loop keeps the release-denial callback live even while a
+    // worker thread does blocking disk I/O — the reason it is preferred.
+    let main_run_loop = match target {
+        RunLoopTarget::Main => CFRunLoop::main().context("failed to get main CFRunLoop")?,
+        RunLoopTarget::Current => {
+            CFRunLoop::current().context("failed to get current CFRunLoop")?
+        }
+    };
     let mode = unsafe { kCFRunLoopDefaultMode.unwrap() };
     unsafe { session.schedule_with_run_loop(&main_run_loop, mode) };
 
@@ -602,22 +642,36 @@ fn da_claim_disk(bsd_name: &str) -> Result<Option<DiskClaim>> {
         );
     }
 
-    // Spin-wait for the claim completion callback (fires on main run loop,
-    // which is pumped by the GUI thread).
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    // Await the claim completion callback. On the main loop we can only wait for
+    // whoever pumps it; on our own loop we pump it ourselves.
+    let deadline = std::time::Instant::now() + timeout;
     while !unsafe { &*state }.done.load(Ordering::SeqCst) {
         if std::time::Instant::now() >= deadline {
             unsafe {
+                // The request may still land after we stop waiting; unclaim so a
+                // late success cannot leave the disk claimed by a session we are
+                // about to drop.
+                disk.unclaim();
                 session.unschedule_from_run_loop(&main_run_loop, mode);
                 let _ = Box::from_raw(state);
             }
-            log::warn!(
-                "DA claim of {} timed out — proceeding without exclusive access",
-                bsd_name
-            );
+            match target {
+                RunLoopTarget::Main => log::debug!(
+                    "DA claim of {bsd_name} saw no main-loop callback within {timeout:?}"
+                ),
+                RunLoopTarget::Current => log::warn!(
+                    "DA claim of {bsd_name} timed out — proceeding without exclusive access"
+                ),
+            }
             return Ok(None);
         }
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        match target {
+            RunLoopTarget::Current => {
+                // Pumping is what makes the callback arrive here at all.
+                CFRunLoop::run_in_mode(Some(mode), 0.05, false);
+            }
+            RunLoopTarget::Main => std::thread::sleep(std::time::Duration::from_millis(50)),
+        }
     }
 
     let state = unsafe { Box::from_raw(state) };
@@ -1043,5 +1097,96 @@ pub fn open_source_for_reading(path: &Path) -> Result<ElevatedSource> {
             temp_path: None,
             disk_claim: None,
         })
+    }
+}
+
+/// Convert a device path to its raw character-device form
+/// (`/dev/disk6` -> `/dev/rdisk6`). Mirrors the spellings `cd-da-reader`
+/// accepts, so the path we escalate is the same node it would have opened.
+fn raw_device_path(device_path: &str) -> String {
+    if device_path.starts_with("/dev/rdisk") {
+        device_path.to_string()
+    } else if let Some(rest) = device_path.strip_prefix("/dev/") {
+        format!("/dev/r{rest}")
+    } else if device_path.starts_with("rdisk") {
+        format!("/dev/{device_path}")
+    } else {
+        format!("/dev/r{device_path}")
+    }
+}
+
+/// Open an optical drive's raw device node for reading, escalating via
+/// `authopen`.
+///
+/// The optical stack (`cd-da-reader`) opens `/dev/rdiskN` itself and has no
+/// privilege escalation of its own, so an unprivileged app — notably the GUI,
+/// which unlike a terminal has no Full Disk Access — just gets `EPERM` and the
+/// user sees "failed to open drive" with no prompt and no way forward. This is
+/// the same fallback [`open_source_for_reading`] performs for whole-disk
+/// backups: `authopen` shows the native macOS authorization dialog and passes
+/// the descriptor back over `SCM_RIGHTS`.
+///
+/// The flags match what `cd-da-reader` would have used on its own open, so the
+/// descriptor behaves identically to the unescalated path. `O_RDONLY` is
+/// deliberate: [`open_source_for_reading`] asks for `O_RDWR` because a backup
+/// may later write, but a write-capable open of an optical device demands
+/// exclusivity we neither need nor want for reading — and it would fail
+/// outright on read-only media.
+/// Take exclusive use of an optical drive for the duration of a read.
+///
+/// Unmounts the disc and claims it through DiskArbitration, so nothing else on
+/// the system competes for the drive — Spotlight indexing, Finder, or another DA
+/// client. That matters more on optical media than anywhere else: every stolen
+/// read costs a physical seek, and the drive has only one head.
+///
+/// Reading itself does **not** require this. The raw `/dev/rdiskN` node reads
+/// fine while the disc is mounted, which is exactly why the device-backed reader
+/// works. This is purely about not sharing the head.
+///
+/// Deliberately non-fatal: a disc that will not unmount (a file still open on
+/// the volume) or will not claim still reads correctly, just with competition.
+/// The returned guard releases the claim on drop; `None` means we are proceeding
+/// without exclusivity.
+pub(crate) fn claim_optical_disc(device_path: &str) -> Option<DiskClaim> {
+    let bsd = bsd_name_from_path(Path::new(device_path));
+
+    if let Err(e) = da_unmount_disk(bsd) {
+        log::info!("{device_path}: could not unmount before claiming ({e}) — continuing shared");
+    }
+
+    match da_claim_disk(bsd) {
+        Ok(Some(claim)) => {
+            log::info!("{device_path}: claimed for exclusive use");
+            Some(claim)
+        }
+        Ok(None) => {
+            log::info!("{device_path}: exclusive claim declined — continuing shared");
+            None
+        }
+        Err(e) => {
+            log::info!("{device_path}: exclusive claim failed ({e}) — continuing shared");
+            None
+        }
+    }
+}
+
+pub fn authopen_optical_device(device_path: &str) -> Result<File> {
+    authopen_device(
+        &raw_device_path(device_path),
+        libc::O_RDONLY | libc::O_NONBLOCK,
+    )
+}
+
+#[cfg(test)]
+mod optical_device_path_tests {
+    use super::raw_device_path;
+
+    #[test]
+    fn maps_every_spelling_to_the_raw_node() {
+        assert_eq!(raw_device_path("/dev/disk6"), "/dev/rdisk6");
+        // Already raw — must not gain a second "r".
+        assert_eq!(raw_device_path("/dev/rdisk6"), "/dev/rdisk6");
+        assert_eq!(raw_device_path("disk6"), "/dev/rdisk6");
+        assert_eq!(raw_device_path("rdisk6"), "/dev/rdisk6");
     }
 }


### PR DESCRIPTION
A USB optical drive was invisible on macOS, and fixing that uncovered three further bugs behind it. Requires opticaldiscs 0.13.0.

Detection (opticaldiscs 0.12.1): enumeration looked only at IODVDDriveNub, a class modern macOS does not use for USB-attached drives — they register as IO{CD,DVD,BD}Services. On a machine whose only drive is external, that matched nothing and the drive list came up empty.

DVD/Blu-ray reading: cd-da-reader speaks MMC/SCSI pass-through, which is the only way to read a CD but is CD-only — DKIOCCDREADTOC/DKIOCCDREAD return ENOTTY on DVD media, so a DVD rip died before reading a sector. A data DVD/BD needs none of it: the drive presents flat 2048-byte cooked sectors. PhysicalDiscSource reads those and synthesises the single-track TOC the rip pipeline expects, so DVD/BD rip to ISO through the existing path. open_local_source picks the reader by capability — a successful TOC read keeps the CD path, so audio CDs are unaffected.

EBUSY: three sites re-opened a drive through the file-based DiscImageInfo::open, which on macOS cannot open /dev/diskN at all while the disc is mounted — disc-info detection, browse-view directory expansion, and the extraction thread. The last two silently swallowed the error, so folders simply rendered empty. Each now routes through the device-backed reader, and load_directory reports the failure.

Exclusive access: rips now unmount and claim the drive via DiskArbitration, so Spotlight and Finder stop competing for the head — measured 4.15 -> 4.97 MB/s. The claim probes the main run loop briefly and falls back to pumping the calling thread's loop, so rb-cli and the TUI get a real claim instead of a silent 10s timeout; no sudo involved, since the device node is already owned by the console user. It is acquired once per rip and handed to whichever reader wins.

Also: an Eject button on the Optical tab, drive capacity in the disc-info row, and "(no disc)" for a connected drive with an empty tray (macOS publishes no device node until media loads).

Verified against a DVD-Video disc in a USB HL-DT-ST DVDRAM GP65NW60: detection, disc info, browse, per-file extraction, and a rip whose ISO browses back with the correct VIDEO_TS tree and file sizes.